### PR TITLE
Usability improvements on JmsMessage

### DIFF
--- a/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
@@ -14,7 +14,7 @@ import jms4s.model.SessionType
 import scala.concurrent.duration.FiniteDuration
 
 trait JmsAcknowledgerConsumer[F[_]] {
-  def handle(f: JmsMessage[F] => F[AckAction[F]]): F[Unit]
+  def handle(f: JmsMessage => F[AckAction[F]]): F[Unit]
 }
 
 object JmsAcknowledgerConsumer {
@@ -41,7 +41,7 @@ object JmsAcknowledgerConsumer {
     blocker: Blocker,
     messageFactory: MessageFactory[F]
   ): JmsAcknowledgerConsumer[F] =
-    (f: JmsMessage[F] => F[AckAction[F]]) =>
+    (f: JmsMessage => F[AckAction[F]]) =>
       Stream
         .emits(0 until concurrencyLevel)
         .as(
@@ -100,7 +100,7 @@ object JmsAcknowledgerConsumer {
     }
 
     private[jms4s] case class ToSend[F[_]](
-      messagesAndDestinations: NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+      messagesAndDestinations: NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     )
 
     def ack[F[_]]: AckAction[F] = Ack()
@@ -108,23 +108,23 @@ object JmsAcknowledgerConsumer {
     def noAck[F[_]]: AckAction[F] = NoAck()
 
     def sendN[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], DestinationName)]]
+      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
     ): Send[F] =
       Send[F](mf =>
         messageFactory(mf).map(nel => nel.map { case (message, name) => (message, (name, None)) }).map(ToSend[F])
       )
 
     def sendNWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]]
+      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
     ): Send[F] =
       Send[F](mf => messageFactory(mf).map(ToSend[F]))
 
     def sendWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+      messageFactory: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     ): Send[F] =
       Send[F](mf => messageFactory(mf).map(x => ToSend[F](NonEmptyList.one(x))))
 
-    def send[F[_]: Functor](messageFactory: MessageFactory[F] => F[(JmsMessage[F], DestinationName)]): Send[F] =
+    def send[F[_]: Functor](messageFactory: MessageFactory[F] => F[(JmsMessage, DestinationName)]): Send[F] =
       Send[F](mf =>
         messageFactory(mf).map { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) }
       )

--- a/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
@@ -14,7 +14,7 @@ import jms4s.model.SessionType
 import scala.concurrent.duration.FiniteDuration
 
 trait JmsAutoAcknowledgerConsumer[F[_]] {
-  def handle(f: JmsMessage[F] => F[AutoAckAction[F]]): F[Unit]
+  def handle(f: JmsMessage => F[AutoAckAction[F]]): F[Unit]
 }
 
 object JmsAutoAcknowledgerConsumer {
@@ -40,7 +40,7 @@ object JmsAutoAcknowledgerConsumer {
     concurrencyLevel: Int,
     messageFactory: MessageFactory[F]
   ): JmsAutoAcknowledgerConsumer[F] =
-    (f: JmsMessage[F] => F[AutoAckAction[F]]) =>
+    (f: JmsMessage => F[AutoAckAction[F]]) =>
       Stream
         .emits(0 until concurrencyLevel)
         .as(
@@ -93,29 +93,29 @@ object JmsAutoAcknowledgerConsumer {
     }
 
     private[jms4s] case class ToSend[F[_]](
-      messagesAndDestinations: NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+      messagesAndDestinations: NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     )
 
     def noOp[F[_]]: NoOp[F] = NoOp[F]()
 
     def sendN[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], DestinationName)]]
+      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
     ): Send[F] =
       Send[F](mf =>
         messageFactory(mf).map(nel => nel.map { case (message, name) => (message, (name, None)) }).map(ToSend[F])
       )
 
     def sendNWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]]
+      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
     ): Send[F] =
       Send[F](mf => messageFactory(mf).map(ToSend[F]))
 
     def sendWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+      messageFactory: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     ): Send[F] =
       Send[F](mf => messageFactory(mf).map(x => ToSend[F](NonEmptyList.one(x))))
 
-    def send[F[_]: Functor](messageFactory: MessageFactory[F] => F[(JmsMessage[F], DestinationName)]): Send[F] =
+    def send[F[_]: Functor](messageFactory: MessageFactory[F] => F[(JmsMessage, DestinationName)]): Send[F] =
       Send[F](mf =>
         messageFactory(mf).map { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) }
       )

--- a/core/src/main/scala/jms4s/JmsProducer.scala
+++ b/core/src/main/scala/jms4s/JmsProducer.scala
@@ -13,18 +13,18 @@ import scala.concurrent.duration.FiniteDuration
 trait JmsProducer[F[_]] {
 
   def sendN(
-    messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], DestinationName)]]
+    messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
   ): F[Unit]
 
   def sendNWithDelay(
-    messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]]
+    messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
   ): F[Unit]
 
   def sendWithDelay(
-    messageFactory: MessageFactory[F] => F[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+    messageFactory: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
   ): F[Unit]
 
-  def send(messageFactory: MessageFactory[F] => F[(JmsMessage[F], DestinationName)]): F[Unit]
+  def send(messageFactory: MessageFactory[F] => F[(JmsMessage, DestinationName)]): F[Unit]
 
 }
 
@@ -48,7 +48,7 @@ object JmsProducer {
     } yield new JmsProducer[F] {
 
       override def sendN(
-        f: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], DestinationName)]]
+        f: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
       ): F[Unit] =
         for {
           ctx                      <- pool.dequeue1
@@ -60,7 +60,7 @@ object JmsProducer {
         } yield ()
 
       override def sendNWithDelay(
-        f: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]]
+        f: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
       ): F[Unit] =
         for {
           ctx                                <- pool.dequeue1
@@ -73,7 +73,7 @@ object JmsProducer {
         } yield ()
 
       override def sendWithDelay(
-        f: MessageFactory[F] => F[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+        f: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
       ): F[Unit] =
         for {
           ctx                                 <- pool.dequeue1
@@ -82,7 +82,7 @@ object JmsProducer {
           _                                   <- pool.enqueue1(ctx)
         } yield ()
 
-      override def send(f: MessageFactory[F] => F[(JmsMessage[F], DestinationName)]): F[Unit] =
+      override def send(f: MessageFactory[F] => F[(JmsMessage, DestinationName)]): F[Unit] =
         for {
           ctx                    <- pool.dequeue1
           (message, destination) <- f(mf)

--- a/core/src/main/scala/jms4s/jms/JmsContext.scala
+++ b/core/src/main/scala/jms4s/jms/JmsContext.scala
@@ -31,12 +31,12 @@ class JmsContext[F[_]: Sync: Logger: ContextShift: Concurrent](
       )
       .map(context => new JmsContext(context, blocker))
 
-  def send(destinationName: DestinationName, message: JmsMessage[F]): F[Unit] =
+  def send(destinationName: DestinationName, message: JmsMessage): F[Unit] =
     createDestination(destinationName)
       .flatMap(destination => blocker.delay(context.createProducer().send(destination.wrapped, message.wrapped)))
       .map(_ => ())
 
-  def send(destinationName: DestinationName, message: JmsMessage[F], delay: FiniteDuration): F[Unit] =
+  def send(destinationName: DestinationName, message: JmsMessage, delay: FiniteDuration): F[Unit] =
     for {
       destination <- createDestination(destinationName)
       p           <- Sync[F].delay(context.createProducer())
@@ -57,7 +57,7 @@ class JmsContext[F[_]: Sync: Logger: ContextShift: Concurrent](
                  )
     } yield new JmsMessageConsumer[F](consumer)
 
-  def createTextMessage(value: String): F[JmsTextMessage[F]] =
+  def createTextMessage(value: String): F[JmsTextMessage] =
     Sync[F].delay(new JmsTextMessage(context.createTextMessage(value)))
 
   def commit: F[Unit] = blocker.delay(context.commit())

--- a/core/src/main/scala/jms4s/jms/JmsMessage.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessage.scala
@@ -79,7 +79,7 @@ class JmsMessage private[jms4s] (private[jms4s] val wrapped: Message) {
 
 object MessageOps {
 
-  implicit def showMessage: Show[Message] = Show.show[Message] { message =>
+  implicit val showMessage: Show[Message] = Show.show[Message] { message =>
     def getStringContent: Try[String] = message match {
       case message: TextMessage => Try(message.getText)
       case _                    => Failure(new RuntimeException())
@@ -113,6 +113,8 @@ object MessageOps {
         """.stripMargin
     }.getOrElse("")
   }
+
+  implicit val showJmsMessage: Show[JmsMessage] = Show.show[JmsMessage](_.wrapped.show)
 }
 
 object JmsMessage {

--- a/core/src/main/scala/jms4s/jms/JmsMessage.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessage.scala
@@ -8,63 +8,72 @@ import jms4s.jms.JmsMessage.{ JmsTextMessage, UnsupportedMessage }
 import jms4s.jms.MessageOps._
 
 import scala.util.control.NoStackTrace
-import scala.util.{ Failure, Try }
+import scala.util.{ Failure, Success, Try }
 
-class JmsMessage[F[_]: Sync] private[jms4s] (private[jms4s] val wrapped: Message) {
+class JmsMessage private[jms4s] (private[jms4s] val wrapped: Message) {
 
-  def attemptAsJmsTextMessage: Either[UnsupportedMessage, JmsTextMessage[F]] = wrapped match {
-    case textMessage: TextMessage => new JmsTextMessage(textMessage).asRight
-    case _                        => UnsupportedMessage(wrapped).asLeft
+  def attemptAsJmsTextMessage: Try[JmsTextMessage] = wrapped match {
+    case textMessage: TextMessage => Success(new JmsTextMessage(textMessage))
+    case _                        => Failure(UnsupportedMessage(wrapped))
   }
 
-  def asJmsTextMessage: F[JmsTextMessage[F]] = wrapped match {
-    case textMessage: TextMessage => new JmsTextMessage(textMessage).pure[F]
-    case _                        => Sync[F].raiseError(UnsupportedMessage(wrapped))
-  }
+  def attemptAsText: Try[String] = attemptAsJmsTextMessage.flatMap(_.getText)
 
-  def setJMSCorrelationId(correlationId: String): F[Unit] = Sync[F].delay(wrapped.setJMSCorrelationID(correlationId))
-  def setJMSReplyTo(destination: JmsDestination): F[Unit] = Sync[F].delay(wrapped.setJMSReplyTo(destination.wrapped))
-  def setJMSType(`type`: String): F[Unit]                 = Sync[F].delay(wrapped.setJMSType(`type`))
+  def asJmsTextMessageF[F[_]: Sync]: F[JmsTextMessage] = Sync[F].fromTry(attemptAsJmsTextMessage)
+  def asTextF[F[_]: Sync]: F[String]                   = Sync[F].fromTry(attemptAsText)
 
-  def setJMSCorrelationIDAsBytes(correlationId: Array[Byte]): F[Unit] =
-    Sync[F].delay(wrapped.setJMSCorrelationIDAsBytes(correlationId))
+  def setJMSCorrelationId(correlationId: String): Try[Unit] = Try(wrapped.setJMSCorrelationID(correlationId))
+  def setJMSReplyTo(destination: JmsDestination): Try[Unit] = Try(wrapped.setJMSReplyTo(destination.wrapped))
+  def setJMSType(`type`: String): Try[Unit]                 = Try(wrapped.setJMSType(`type`))
 
-  val getJMSMessageId: F[String]                 = Sync[F].delay(wrapped.getJMSMessageID)
-  val getJMSTimestamp: F[Long]                   = Sync[F].delay(wrapped.getJMSTimestamp)
-  val getJMSCorrelationId: F[String]             = Sync[F].delay(wrapped.getJMSCorrelationID)
-  val getJMSCorrelationIdAsBytes: F[Array[Byte]] = Sync[F].delay(wrapped.getJMSCorrelationIDAsBytes)
-  val getJMSReplyTo: F[Destination]              = Sync[F].delay(wrapped.getJMSReplyTo)
-  val getJMSDestination: F[Destination]          = Sync[F].delay(wrapped.getJMSDestination)
-  val getJMSDeliveryMode: F[Int]                 = Sync[F].delay(wrapped.getJMSDeliveryMode)
-  val getJMSRedelivered: F[Boolean]              = Sync[F].delay(wrapped.getJMSRedelivered)
-  val getJMSType: F[String]                      = Sync[F].delay(wrapped.getJMSType)
-  val getJMSExpiration: F[Long]                  = Sync[F].delay(wrapped.getJMSExpiration)
-  val getJMSPriority: F[Int]                     = Sync[F].delay(wrapped.getJMSPriority)
-  val getJMSDeliveryTime: F[Long]                = Sync[F].delay(wrapped.getJMSDeliveryTime)
+  def setJMSCorrelationIDAsBytes(correlationId: Array[Byte]): Try[Unit] =
+    Try(wrapped.setJMSCorrelationIDAsBytes(correlationId))
 
-  def getBooleanProperty(name: String): F[Boolean] =
-    Sync[F].delay(wrapped.getBooleanProperty(name))
+  val getJMSMessageId: Try[String]                 = Try(wrapped.getJMSMessageID)
+  val getJMSTimestamp: Try[Long]                   = Try(wrapped.getJMSTimestamp)
+  val getJMSCorrelationId: Try[String]             = Try(wrapped.getJMSCorrelationID)
+  val getJMSCorrelationIdAsBytes: Try[Array[Byte]] = Try(wrapped.getJMSCorrelationIDAsBytes)
+  val getJMSReplyTo: Try[Destination]              = Try(wrapped.getJMSReplyTo)
+  val getJMSDestination: Try[Destination]          = Try(wrapped.getJMSDestination)
+  val getJMSDeliveryMode: Try[Int]                 = Try(wrapped.getJMSDeliveryMode)
+  val getJMSRedelivered: Try[Boolean]              = Try(wrapped.getJMSRedelivered)
+  val getJMSType: Try[String]                      = Try(wrapped.getJMSType)
+  val getJMSExpiration: Try[Long]                  = Try(wrapped.getJMSExpiration)
+  val getJMSPriority: Try[Int]                     = Try(wrapped.getJMSPriority)
+  val getJMSDeliveryTime: Try[Long]                = Try(wrapped.getJMSDeliveryTime)
 
-  def getByteProperty(name: String): F[Byte] =
-    Sync[F].delay(wrapped.getByteProperty(name))
+  def getBooleanProperty(name: String): Try[Boolean] =
+    Try(wrapped.getBooleanProperty(name))
 
-  def getDoubleProperty(name: String): F[Double] =
-    Sync[F].delay(wrapped.getDoubleProperty(name))
+  def getByteProperty(name: String): Try[Byte] =
+    Try(wrapped.getByteProperty(name))
 
-  def getFloatProperty(name: String): F[Float] =
-    Sync[F].delay(wrapped.getFloatProperty(name))
+  def getDoubleProperty(name: String): Try[Double] =
+    Try(wrapped.getDoubleProperty(name))
 
-  def getIntProperty(name: String): F[Int] =
-    Sync[F].delay(wrapped.getIntProperty(name))
+  def getFloatProperty(name: String): Try[Float] =
+    Try(wrapped.getFloatProperty(name))
 
-  def getLongProperty(name: String): F[Long] =
-    Sync[F].delay(wrapped.getLongProperty(name))
+  def getIntProperty(name: String): Try[Int] =
+    Try(wrapped.getIntProperty(name))
 
-  def getShortProperty(name: String): F[Short] =
-    Sync[F].delay(wrapped.getShortProperty(name))
+  def getLongProperty(name: String): Try[Long] =
+    Try(wrapped.getLongProperty(name))
 
-  def getStringProperty(name: String): F[String] =
-    Sync[F].delay(wrapped.getStringProperty(name))
+  def getShortProperty(name: String): Try[Short] =
+    Try(wrapped.getShortProperty(name))
+
+  def getStringProperty(name: String): Try[String] =
+    Try(wrapped.getStringProperty(name))
+
+  def setBooleanProperty(name: String, value: Boolean): Try[Unit] = Try(wrapped.setBooleanProperty(name, value))
+  def setByteProperty(name: String, value: Byte): Try[Unit]       = Try(wrapped.setByteProperty(name, value))
+  def setDoubleProperty(name: String, value: Double): Try[Unit]   = Try(wrapped.setDoubleProperty(name, value))
+  def setFloatProperty(name: String, value: Float): Try[Unit]     = Try(wrapped.setFloatProperty(name, value))
+  def setIntProperty(name: String, value: Int): Try[Unit]         = Try(wrapped.setIntProperty(name, value))
+  def setLongProperty(name: String, value: Long): Try[Unit]       = Try(wrapped.setLongProperty(name, value))
+  def setShortProperty(name: String, value: Short): Try[Unit]     = Try(wrapped.setShortProperty(name, value))
+  def setStringProperty(name: String, value: String): Try[Unit]   = Try(wrapped.setStringProperty(name, value))
 
 }
 
@@ -112,12 +121,11 @@ object JmsMessage {
       extends Exception("Unsupported Message: " + message.show)
       with NoStackTrace
 
-  class JmsTextMessage[F[_]: Sync] private[jms4s] (override private[jms4s] val wrapped: TextMessage)
-      extends JmsMessage[F](wrapped) {
+  class JmsTextMessage private[jms4s] (override private[jms4s] val wrapped: TextMessage) extends JmsMessage(wrapped) {
 
-    def setText(text: String): F[Unit] =
-      Sync[F].delay(wrapped.setText(text))
+    def setText(text: String): Try[Unit] =
+      Try(wrapped.setText(text))
 
-    val getText: F[String] = Sync[F].delay(wrapped.getText)
+    val getText: Try[String] = Try(wrapped.getText)
   }
 }

--- a/core/src/main/scala/jms4s/jms/JmsMessageConsumer.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessageConsumer.scala
@@ -9,7 +9,7 @@ class JmsMessageConsumer[F[_]: ContextShift: Concurrent: Logger] private[jms4s] 
   private[jms4s] val wrapped: JMSConsumer
 ) {
 
-  val receiveJmsMessage: F[JmsMessage[F]] =
+  val receiveJmsMessage: F[JmsMessage] =
     interruptable(force = true) {
       val message = wrapped.receive()
       new JmsMessage(message)

--- a/core/src/main/scala/jms4s/jms/MessageFactory.scala
+++ b/core/src/main/scala/jms4s/jms/MessageFactory.scala
@@ -4,7 +4,7 @@ import cats.effect.Sync
 import jms4s.jms.JmsMessage.JmsTextMessage
 
 class MessageFactory[F[_]: Sync](context: JmsContext[F]) {
-  def makeTextMessage(value: String): F[JmsTextMessage[F]] = context.createTextMessage(value)
+  def makeTextMessage(value: String): F[JmsTextMessage] = context.createTextMessage(value)
 }
 
 object MessageFactory {

--- a/examples/src/main/scala/AckConsumerExample.scala
+++ b/examples/src/main/scala/AckConsumerExample.scala
@@ -28,8 +28,7 @@ class AckConsumerExample extends IOApp {
 
     consumerRes.use(_.handle { jmsMessage =>
       for {
-        tm   <- jmsMessage.asJmsTextMessage
-        text <- tm.getText
+        text <- jmsMessage.asTextF[IO]
         res  <- yourBusinessLogic(text)
       } yield res
     }.as(ExitCode.Success))

--- a/examples/src/main/scala/AutoAckConsumerExample.scala
+++ b/examples/src/main/scala/AutoAckConsumerExample.scala
@@ -26,8 +26,7 @@ class AutoAckConsumerExample extends IOApp {
 
     consumerRes.use(_.handle { jmsMessage =>
       for {
-        tm   <- jmsMessage.asJmsTextMessage
-        text <- tm.getText
+        text <- jmsMessage.asTextF[IO]
         res  <- yourBusinessLogic(text)
       } yield res
     }.as(ExitCode.Success))

--- a/examples/src/main/scala/ProducerExample.scala
+++ b/examples/src/main/scala/ProducerExample.scala
@@ -36,7 +36,7 @@ class ProducerExample extends IOApp {
   private def make1(
     text: String,
     destinationName: DestinationName
-  ): MessageFactory[IO] => IO[(JmsTextMessage[IO], DestinationName)] = { mFactory =>
+  ): MessageFactory[IO] => IO[(JmsTextMessage, DestinationName)] = { mFactory =>
     mFactory
       .makeTextMessage(text)
       .map(message => (message, destinationName))
@@ -45,7 +45,7 @@ class ProducerExample extends IOApp {
   private def makeN(
     texts: NonEmptyList[String],
     destinationName: DestinationName
-  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage[IO], DestinationName)]] = { mFactory =>
+  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage, DestinationName)]] = { mFactory =>
     texts.traverse { text =>
       mFactory
         .makeTextMessage(text)
@@ -57,7 +57,7 @@ class ProducerExample extends IOApp {
     text: String,
     destinationName: DestinationName,
     delay: FiniteDuration
-  ): MessageFactory[IO] => IO[(JmsTextMessage[IO], (DestinationName, Option[FiniteDuration]))] = { mFactory =>
+  ): MessageFactory[IO] => IO[(JmsTextMessage, (DestinationName, Option[FiniteDuration]))] = { mFactory =>
     mFactory
       .makeTextMessage(text)
       .map(message => (message, (destinationName, Some(delay))))
@@ -67,12 +67,11 @@ class ProducerExample extends IOApp {
     texts: NonEmptyList[String],
     destinationName: DestinationName,
     delay: FiniteDuration
-  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage[IO], (DestinationName, Option[FiniteDuration]))]] = {
-    mFactory =>
-      texts.traverse { text =>
-        mFactory
-          .makeTextMessage(text)
-          .map(message => (message, (destinationName, Some(delay))))
-      }
+  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage, (DestinationName, Option[FiniteDuration]))]] = { mFactory =>
+    texts.traverse { text =>
+      mFactory
+        .makeTextMessage(text)
+        .map(message => (message, (destinationName, Some(delay))))
+    }
   }
 }

--- a/examples/src/main/scala/TransactedConsumerExample.scala
+++ b/examples/src/main/scala/TransactedConsumerExample.scala
@@ -28,8 +28,7 @@ class TransactedConsumerExample extends IOApp {
 
     consumerRes.use(_.handle { jmsMessage =>
       for {
-        tm   <- jmsMessage.asJmsTextMessage
-        text <- tm.getText
+        text <- jmsMessage.asTextF[IO]
         res  <- yourBusinessLogic(text)
       } yield res
     }.as(ExitCode.Success))

--- a/site/docs/programs/ack-consumer/index.md
+++ b/site/docs/programs/ack-consumer/index.md
@@ -9,7 +9,7 @@ A `JmsAcknowledgerConsumer` is a consumer which let the client decide whether co
 Its only operation is:
 
 ```scala
-def handle(f: JmsMessage[F] => F[AckAction[F]]): F[Unit]
+def handle(f: JmsMessage => F[AckAction[F]]): F[Unit]
 ```
 
 This is where the user of the API can specify its business logic, which can be any effectful operation.
@@ -54,8 +54,7 @@ class AckConsumerExample extends IOApp {
 
     consumerRes.use(_.handle { jmsMessage =>
       for {
-        tm   <- jmsMessage.asJmsTextMessage
-        text <- tm.getText
+        text <- jmsMessage.asTextF[IO]
         res  <- yourBusinessLogic(text)
       } yield res
     }.as(ExitCode.Success))

--- a/site/docs/programs/auto-ack-consumer/index.md
+++ b/site/docs/programs/auto-ack-consumer/index.md
@@ -9,7 +9,7 @@ A `JmsAutoAcknowledgerConsumer` is a consumer that will automatically acknowledg
 Its only operation is:
 
 ```scala
-def handle(f: JmsMessage[F] => F[AutoAckAction[F]]): F[Unit]
+def handle(f: JmsMessage => F[AutoAckAction[F]]): F[Unit]
 ```
 
 This is where the user of the API can specify its business logic, which can be any effectful operation.
@@ -51,11 +51,11 @@ class AutoAckConsumerExample extends IOApp {
 
     consumerRes.use(_.handle { jmsMessage =>
       for {
-        tm   <- jmsMessage.asJmsTextMessage
-        text <- tm.getText
+        text <- jmsMessage.asTextF[IO]
         res  <- yourBusinessLogic(text)
       } yield res
     }.as(ExitCode.Success))
   }
 }
+
 ```

--- a/site/docs/programs/producer/index.md
+++ b/site/docs/programs/producer/index.md
@@ -10,27 +10,27 @@ A `JmsProducer` is a producer that lets the client publish a message in queues/t
 - sendN: to send N messages to N Destinations.
 ```scala
 def sendN(
-  makeN: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], DestinationName)]]
+  makeN: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
 ): F[Unit]
 ```
 
 - sendNWithDelay: to send N messages to N Destinations with an optional delay.
 ```scala
   def sendNWithDelay(
-    makeNWithDelay: MessageFactory[F] => F[NonEmptyList[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]]
+    makeNWithDelay: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
   ): F[Unit]
 ```
 
 - sendWithDelay: to send a message to a Destination.
 ```scala
   def sendWithDelay(
-    make1WithDelay: MessageFactory[F] => F[(JmsMessage[F], (DestinationName, Option[FiniteDuration]))]
+    make1WithDelay: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
   ): F[Unit]
 ```
 - send: to send a message to a Destination.
 ```scala
   def send(
-    make1: MessageFactory[F] => F[(JmsMessage[F], DestinationName)]
+    make1: MessageFactory[F] => F[(JmsMessage, DestinationName)]
   ): F[Unit]
 ```
 
@@ -78,7 +78,7 @@ class ProducerExample extends IOApp {
   private def make1(
     text: String,
     destinationName: DestinationName
-  ): MessageFactory[IO] => IO[(JmsTextMessage[IO], DestinationName)] = { mFactory =>
+  ): MessageFactory[IO] => IO[(JmsTextMessage, DestinationName)] = { mFactory =>
     mFactory
       .makeTextMessage(text)
       .map(message => (message, destinationName))
@@ -87,7 +87,7 @@ class ProducerExample extends IOApp {
   private def makeN(
     texts: NonEmptyList[String],
     destinationName: DestinationName
-  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage[IO], DestinationName)]] = { mFactory =>
+  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage, DestinationName)]] = { mFactory =>
     texts.traverse { text =>
       mFactory
         .makeTextMessage(text)
@@ -99,7 +99,7 @@ class ProducerExample extends IOApp {
     text: String,
     destinationName: DestinationName,
     delay: FiniteDuration
-  ): MessageFactory[IO] => IO[(JmsTextMessage[IO], (DestinationName, Option[FiniteDuration]))] = { mFactory =>
+  ): MessageFactory[IO] => IO[(JmsTextMessage, (DestinationName, Option[FiniteDuration]))] = { mFactory =>
     mFactory
       .makeTextMessage(text)
       .map(message => (message, (destinationName, Some(delay))))
@@ -109,15 +109,15 @@ class ProducerExample extends IOApp {
     texts: NonEmptyList[String],
     destinationName: DestinationName,
     delay: FiniteDuration
-  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage[IO], (DestinationName, Option[FiniteDuration]))]] = {
-    mFactory =>
-      texts.traverse { text =>
-        mFactory
-          .makeTextMessage(text)
-          .map(message => (message, (destinationName, Some(delay))))
-      }
+  ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage, (DestinationName, Option[FiniteDuration]))]] = { mFactory =>
+    texts.traverse { text =>
+      mFactory
+        .makeTextMessage(text)
+        .map(message => (message, (destinationName, Some(delay))))
+    }
   }
 }
+
 ```
 
 ### A note on concurrency

--- a/site/docs/programs/tx-consumer/index.md
+++ b/site/docs/programs/tx-consumer/index.md
@@ -9,7 +9,7 @@ A `JmsTransactedConsumer` is a consumer that will use a local transaction to rec
 Its only operation is:
 
 ```scala
-def handle(f: JmsMessage[F] => F[TransactionAction[F]]): F[Unit]
+def handle(f: JmsMessage => F[TransactionAction[F]]): F[Unit]
 ```
 
 This is where the user of the API can specify its business logic, which can be any effectful operation.
@@ -54,8 +54,7 @@ class TransactedConsumerExample extends IOApp {
 
     consumerRes.use(_.handle { jmsMessage =>
       for {
-        tm   <- jmsMessage.asJmsTextMessage
-        text <- tm.getText
+        text <- jmsMessage.asTextF[IO]
         res  <- yourBusinessLogic(text)
       } yield res
     }.as(ExitCode.Success))

--- a/tests/src/test/scala/jms4s/jms/JmsSpec.scala
+++ b/tests/src/test/scala/jms4s/jms/JmsSpec.scala
@@ -39,8 +39,7 @@ trait JmsSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           _                 <- sendContext.send(inputQueueName, msg, delay)
           msg               <- consumer.receiveJmsMessage
           deliveryTime      <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
-          tm                <- msg.asJmsTextMessage
-          actualBody        <- tm.getText
+          actualBody        <- msg.asTextF[IO]
           actualDelay       = (deliveryTime - producerTimestamp).millis
         } yield assert(actualDelay >= delayWithTolerance && actualBody == body)
     }


### PR DESCRIPTION
A bunch of things which I found when integrating the lib in a project:
- a `Show` instance for `JmsMessage` was missing (it can be useful for logging, etc..)
- all the ops in `JmsMessage` were exposing `F`. I believe `Try` is enough since those ops are not doing any IO (network, etc..) but are merely getter/setter.
- a bunch of setters was missing
- adjusted the following util ops

```scala
  def attemptAsJmsTextMessage: Try[JmsTextMessage]
  def attemptAsText: Try[String] 
  def asJmsTextMessageF[F[_]: Sync]: F[JmsTextMessage] 
  def asTextF[F[_]: Sync]: F[String]                
```