### PR TITLE
Update handling in consumers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ jobs:
       script: sbt ++$TRAVIS_SCALA_VERSION scalafmtCheckAll
     - name: test 2.13
       scala: *scala_version_213
-      before_script: docker-compose up -d
+      before_script: docker-compose up --renew-anon-volumes --force-recreate -d
       script: sbt ++$TRAVIS_SCALA_VERSION test
       after_script: docker-compose down
     - name: test 2.12
       scala: *scala_version_212
-      before_script: docker-compose up -d
+      before_script: docker-compose up --renew-anon-volumes --force-recreate -d
       script: sbt ++$TRAVIS_SCALA_VERSION test
       after_script: docker-compose down
     - name: site

--- a/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
@@ -109,10 +109,14 @@ object JmsAcknowledgerConsumer {
       messages: NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     ): Send[F] = Send[F](ToSend(messages))
 
-    def sendWithDelay[F[_]: Functor](message: (JmsMessage, (DestinationName, Option[FiniteDuration]))): Send[F] =
-      Send[F](ToSend[F](NonEmptyList.one(message)))
+    def sendWithDelay[F[_]](
+      message: JmsMessage,
+      destination: DestinationName,
+      duration: Option[FiniteDuration]
+    ): Send[F] =
+      Send[F](ToSend[F](NonEmptyList.one((message, (destination, duration)))))
 
-    def send[F[_]: Functor](message: (JmsMessage, DestinationName)): Send[F] =
-      Send[F](message match { case (m, n) => ToSend[F](NonEmptyList.one((m, (n, None)))) })
+    def send[F[_]: Functor](message: JmsMessage, destination: DestinationName): Send[F] =
+      Send[F](ToSend[F](NonEmptyList.one((message, (destination, None)))))
   }
 }

--- a/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import fs2.Stream
 import fs2.concurrent.Queue
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
+import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction.Send
 import jms4s.config.DestinationName
 import jms4s.jms._
 import jms4s.model.SessionType
@@ -14,7 +15,7 @@ import jms4s.model.SessionType
 import scala.concurrent.duration.FiniteDuration
 
 trait JmsAutoAcknowledgerConsumer[F[_]] {
-  def handle(f: JmsMessage => F[AutoAckAction[F]]): F[Unit]
+  def handle(f: (JmsMessage, MessageFactory[F]) => F[AutoAckAction[F]]): F[Unit]
 }
 
 object JmsAutoAcknowledgerConsumer {
@@ -25,47 +26,45 @@ object JmsAutoAcknowledgerConsumer {
     concurrencyLevel: Int
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
     for {
-      pool <- Resource.liftF(Queue.bounded[F, (JmsContext[F], JmsMessageConsumer[F])](concurrencyLevel))
+      pool <- Resource.liftF(
+               Queue.bounded[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])](concurrencyLevel)
+             )
       _ <- (0 until concurrencyLevel).toList.traverse_ { _ =>
             for {
               ctx      <- context.createContext(SessionType.AutoAcknowledge)
               consumer <- ctx.createJmsConsumer(inputDestinationName)
-              _        <- Resource.liftF(pool.enqueue1((ctx, consumer)))
+              _        <- Resource.liftF(pool.enqueue1((ctx, consumer, MessageFactory[F](ctx))))
             } yield ()
           }
-    } yield build(pool, concurrencyLevel, MessageFactory[F](context))
+    } yield build(pool, concurrencyLevel)
 
   private def build[F[_]: ContextShift: Concurrent](
-    pool: Queue[F, (JmsContext[F], JmsMessageConsumer[F])],
-    concurrencyLevel: Int,
-    messageFactory: MessageFactory[F]
-  ): JmsAutoAcknowledgerConsumer[F] =
-    (f: JmsMessage => F[AutoAckAction[F]]) =>
+    pool: Queue[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])],
+    concurrencyLevel: Int
+  ): JmsAutoAcknowledgerConsumer[F] = new JmsAutoAcknowledgerConsumer[F] {
+
+    override def handle(f: (JmsMessage, MessageFactory[F]) => F[AutoAckAction[F]]): F[Unit] =
       Stream
         .emits(0 until concurrencyLevel)
         .as(
           Stream.eval(
             for {
-              (context, consumer) <- pool.dequeue1
-              message             <- consumer.receiveJmsMessage
-              res                 <- f(message)
+              (context, consumer, mf) <- pool.dequeue1
+              message                 <- consumer.receiveJmsMessage
+              res: AutoAckAction[F]   <- f(message, mf)
               _ <- res.fold(
                     ifNoOp = Sync[F].unit,
-                    ifSend = send =>
-                      send
-                        .createMessages(messageFactory)
-                        .flatMap(toSend =>
-                          toSend.messagesAndDestinations.traverse_ {
-                            case (message, (name, delay)) =>
-                              delay.fold(
-                                ifEmpty = context.send(name, message)
-                              )(
-                                f = d => context.send(name, message, d)
-                              )
-                          }
-                        )
+                    ifSend = (send: Send[F]) =>
+                      send.messages.messagesAndDestinations.traverse_ {
+                        case (message, (name, delay)) =>
+                          delay.fold(
+                            ifEmpty = context.send(name, message)
+                          )(
+                            f = d => context.send(name, message, d)
+                          )
+                      }
                   )
-              _ <- pool.enqueue1((context, consumer))
+              _ <- pool.enqueue1((context, consumer, mf))
             } yield ()
           )
         )
@@ -73,6 +72,7 @@ object JmsAutoAcknowledgerConsumer {
         .repeat
         .compile
         .drain
+  }
 
   sealed abstract class AutoAckAction[F[_]] extends Product with Serializable {
     def fold(ifNoOp: => F[Unit], ifSend: AutoAckAction.Send[F] => F[Unit]): F[Unit]
@@ -84,9 +84,7 @@ object JmsAutoAcknowledgerConsumer {
       override def fold(ifNoOp: => F[Unit], ifSend: Send[F] => F[Unit]): F[Unit] = ifNoOp
     }
 
-    case class Send[F[_]](
-      createMessages: MessageFactory[F] => F[ToSend[F]]
-    ) extends AutoAckAction[F] {
+    case class Send[F[_]](messages: ToSend[F]) extends AutoAckAction[F] {
 
       override def fold(ifNoOp: => F[Unit], ifSend: Send[F] => F[Unit]): F[Unit] =
         ifSend(this)
@@ -99,25 +97,21 @@ object JmsAutoAcknowledgerConsumer {
     def noOp[F[_]]: NoOp[F] = NoOp[F]()
 
     def sendN[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
+      messages: NonEmptyList[(JmsMessage, DestinationName)]
     ): Send[F] =
-      Send[F](mf =>
-        messageFactory(mf).map(nel => nel.map { case (message, name) => (message, (name, None)) }).map(ToSend[F])
-      )
+      Send[F](ToSend[F](messages.map { case (message, name) => (message, (name, None)) }))
 
     def sendNWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
+      messages: NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     ): Send[F] =
-      Send[F](mf => messageFactory(mf).map(ToSend[F]))
+      Send[F](ToSend[F](messages.map { case (message, (name, delay)) => (message, (name, delay)) }))
 
     def sendWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
+      message: (JmsMessage, (DestinationName, Option[FiniteDuration]))
     ): Send[F] =
-      Send[F](mf => messageFactory(mf).map(x => ToSend[F](NonEmptyList.one(x))))
+      Send[F](ToSend[F](NonEmptyList.one(message)))
 
-    def send[F[_]: Functor](messageFactory: MessageFactory[F] => F[(JmsMessage, DestinationName)]): Send[F] =
-      Send[F](mf =>
-        messageFactory(mf).map { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) }
-      )
+    def send[F[_]: Functor](message: (JmsMessage, DestinationName)): Send[F] =
+      Send[F](message match { case (m, name) => ToSend[F](NonEmptyList.one((m, (name, None)))) })
   }
 }

--- a/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
@@ -15,7 +15,7 @@ import jms4s.model.SessionType
 import scala.concurrent.duration.FiniteDuration
 
 trait JmsTransactedConsumer[F[_]] {
-  def handle(f: JmsMessage => F[TransactionAction[F]]): F[Unit]
+  def handle(f: (JmsMessage, MessageFactory[F]) => F[TransactionAction[F]]): F[Unit]
 }
 
 object JmsTransactedConsumer {
@@ -26,46 +26,43 @@ object JmsTransactedConsumer {
     concurrencyLevel: Int
   ): Resource[F, JmsTransactedConsumer[F]] =
     for {
-      pool <- Resource.liftF(Queue.bounded[F, (JmsContext[F], JmsMessageConsumer[F])](concurrencyLevel))
+      pool <- Resource.liftF(
+               Queue.bounded[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])](concurrencyLevel)
+             )
       _ <- (0 until concurrencyLevel).toList
             .traverse_(_ =>
               for {
                 c        <- context.createContext(SessionType.Transacted)
                 consumer <- c.createJmsConsumer(inputDestinationName)
-                _        <- Resource.liftF(pool.enqueue1((c, consumer)))
+                _        <- Resource.liftF(pool.enqueue1((c, consumer, MessageFactory[F](c))))
               } yield ()
             )
-    } yield build(new JmsTransactedConsumerPool[F](pool), concurrencyLevel, MessageFactory[F](context))
+    } yield build(new JmsTransactedConsumerPool[F](pool), concurrencyLevel)
 
   private def build[F[_]: ContextShift: Concurrent](
     pool: JmsTransactedConsumerPool[F],
-    concurrencyLevel: Int,
-    messageFactory: MessageFactory[F]
-  ): JmsTransactedConsumer[F] =
-    (f: JmsMessage => F[TransactionAction[F]]) =>
+    concurrencyLevel: Int
+  ): JmsTransactedConsumer[F] = new JmsTransactedConsumer[F] {
+
+    override def handle(f: (JmsMessage, MessageFactory[F]) => F[TransactionAction[F]]): F[Unit] =
       Stream
         .emits(0 until concurrencyLevel)
         .as(
           Stream.eval(
             fo = for {
               received <- pool.receive
-              tResult  <- f(received.message)
+              tResult  <- f(received.message, received.messageFactory)
               _ <- tResult.fold(
-                    ifCommit = pool.commit(received.context, received.consumer),
-                    ifRollback = pool.rollback(received.context, received.consumer),
-                    ifSend = send => {
-                      send
-                        .createMessages(messageFactory)
-                        .flatMap(toSend =>
-                          toSend.messagesAndDestinations.traverse_ {
-                            case (message, (name, delay)) =>
-                              delay.fold(
-                                received.context.send(name, message)
-                              )(d => received.context.send(name, message, d)) *> pool
-                                .commit(received.context, received.consumer)
-                          }
-                        )
-                    }
+                    ifCommit = pool.commit(received.context, received.consumer, received.messageFactory),
+                    ifRollback = pool.rollback(received.context, received.consumer, received.messageFactory),
+                    ifSend = send =>
+                      send.messages.messagesAndDestinations.traverse_ {
+                        case (message, (name, delay)) =>
+                          delay.fold(
+                            received.context.send(name, message)
+                          )(d => received.context.send(name, message, d)) *>
+                            pool.commit(received.context, received.consumer, received.messageFactory)
+                      }
                   )
             } yield ()
           )
@@ -74,32 +71,39 @@ object JmsTransactedConsumer {
         .repeat
         .compile
         .drain
+  }
 
   private[jms4s] class JmsTransactedConsumerPool[F[_]: Concurrent: ContextShift](
-    pool: Queue[F, (JmsContext[F], JmsMessageConsumer[F])]
+    pool: Queue[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])]
   ) {
 
     val receive: F[Received[F]] =
       for {
-        (context, consumer) <- pool.dequeue1
-        message             <- consumer.receiveJmsMessage
-      } yield Received(message, context, consumer)
+        (context, consumer, mf) <- pool.dequeue1
+        message                 <- consumer.receiveJmsMessage
+      } yield Received(message, context, consumer, mf)
 
-    def commit(context: JmsContext[F], consumer: JmsMessageConsumer[F]): F[Unit] =
+    def commit(context: JmsContext[F], consumer: JmsMessageConsumer[F], mf: MessageFactory[F]): F[Unit] =
       for {
         _ <- context.commit
-        _ <- pool.enqueue1((context, consumer))
+        _ <- pool.enqueue1((context, consumer, mf))
       } yield ()
 
-    def rollback(context: JmsContext[F], consumer: JmsMessageConsumer[F]): F[Unit] =
+    def rollback(context: JmsContext[F], consumer: JmsMessageConsumer[F], mf: MessageFactory[F]): F[Unit] =
       for {
         _ <- context.rollback
-        _ <- pool.enqueue1((context, consumer))
+        _ <- pool.enqueue1((context, consumer, mf))
       } yield ()
   }
 
   object JmsTransactedConsumerPool {
-    case class Received[F[_]](message: JmsMessage, context: JmsContext[F], consumer: JmsMessageConsumer[F])
+
+    case class Received[F[_]](
+      message: JmsMessage,
+      context: JmsContext[F],
+      consumer: JmsMessageConsumer[F],
+      messageFactory: MessageFactory[F]
+    )
   }
 
   sealed abstract class TransactionAction[F[_]] extends Product with Serializable {
@@ -116,9 +120,7 @@ object JmsTransactedConsumer {
       override def fold(ifCommit: => F[Unit], ifRollback: => F[Unit], ifSend: Send[F] => F[Unit]): F[Unit] = ifRollback
     }
 
-    case class Send[F[_]](
-      createMessages: MessageFactory[F] => F[ToSend[F]]
-    ) extends TransactionAction[F] {
+    case class Send[F[_]](messages: ToSend[F]) extends TransactionAction[F] {
 
       override def fold(ifCommit: => F[Unit], ifRollback: => F[Unit], ifSend: Send[F] => F[Unit]): F[Unit] =
         ifSend(this)
@@ -132,26 +134,18 @@ object JmsTransactedConsumer {
 
     def rollback[F[_]]: TransactionAction[F] = Rollback[F]()
 
-    def sendN[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, DestinationName)]]
-    ): Send[F] =
-      Send[F](mf =>
-        messageFactory(mf).map(nel => nel.map { case (message, name) => (message, (name, None)) }).map(ToSend[F])
-      )
+    def sendN[F[_]: Functor](messages: NonEmptyList[(JmsMessage, DestinationName)]): Send[F] =
+      Send[F](ToSend[F](messages.map { case (message, name) => (message, (name, None)) }))
 
     def sendNWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]]
+      messages: NonEmptyList[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
     ): Send[F] =
-      Send[F](mf => messageFactory(mf).map(ToSend[F]))
+      Send[F](ToSend[F](messages.map { case (message, (name, delay)) => (message, (name, delay)) }))
 
-    def sendWithDelay[F[_]: Functor](
-      messageFactory: MessageFactory[F] => F[(JmsMessage, (DestinationName, Option[FiniteDuration]))]
-    ): Send[F] =
-      Send[F](mf => messageFactory(mf).map(x => ToSend[F](NonEmptyList.one(x))))
+    def sendWithDelay[F[_]: Functor](message: (JmsMessage, (DestinationName, Option[FiniteDuration]))): Send[F] =
+      Send[F](ToSend[F](NonEmptyList.one(message)))
 
-    def send[F[_]: Functor](messageFactory: MessageFactory[F] => F[(JmsMessage, DestinationName)]): Send[F] =
-      Send[F](mf =>
-        messageFactory(mf).map { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) }
-      )
+    def send[F[_]: Functor](message: (JmsMessage, DestinationName)): Send[F] =
+      Send[F](message match { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) })
   }
 }

--- a/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
@@ -145,7 +145,7 @@ object JmsTransactedConsumer {
     def sendWithDelay[F[_]: Functor](message: (JmsMessage, (DestinationName, Option[FiniteDuration]))): Send[F] =
       Send[F](ToSend[F](NonEmptyList.one(message)))
 
-    def send[F[_]: Functor](message: (JmsMessage, DestinationName)): Send[F] =
+    def send[F[_]](message: (JmsMessage, DestinationName)): Send[F] =
       Send[F](message match { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) })
   }
 }

--- a/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
@@ -142,10 +142,14 @@ object JmsTransactedConsumer {
     ): Send[F] =
       Send[F](ToSend[F](messages.map { case (message, (name, delay)) => (message, (name, delay)) }))
 
-    def sendWithDelay[F[_]: Functor](message: (JmsMessage, (DestinationName, Option[FiniteDuration]))): Send[F] =
-      Send[F](ToSend[F](NonEmptyList.one(message)))
+    def sendWithDelay[F[_]](
+      message: JmsMessage,
+      destination: DestinationName,
+      duration: Option[FiniteDuration]
+    ): Send[F] =
+      Send[F](ToSend[F](NonEmptyList.one((message, (destination, duration)))))
 
-    def send[F[_]](message: (JmsMessage, DestinationName)): Send[F] =
-      Send[F](message match { case (message, name) => ToSend[F](NonEmptyList.one((message, (name, None)))) })
+    def send[F[_]](message: JmsMessage, destination: DestinationName): Send[F] =
+      Send[F](ToSend[F](NonEmptyList.one((message, (destination, None)))))
   }
 }

--- a/examples/src/main/scala/AckConsumerExample.scala
+++ b/examples/src/main/scala/AckConsumerExample.scala
@@ -13,7 +13,7 @@ class AckConsumerExample extends IOApp {
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AckAction[IO]] =
     if (text.toInt % 2 == 0)
-      mf.makeTextMessage("a brand new message").map(newMsg => AckAction.send((newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => AckAction.send(newMsg, outputTopic))
     else if (text.toInt % 3 == 0)
       IO.pure(AckAction.noAck)
     else

--- a/examples/src/main/scala/AckConsumerExample.scala
+++ b/examples/src/main/scala/AckConsumerExample.scala
@@ -2,7 +2,7 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.JmsContext
+import jms4s.jms.{ JmsContext, MessageFactory }
 
 class AckConsumerExample extends IOApp {
 
@@ -11,14 +11,13 @@ class AckConsumerExample extends IOApp {
   val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
   val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
 
-  def yourBusinessLogic(text: String): IO[AckAction[IO]] = IO.delay {
+  def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AckAction[IO]] =
     if (text.toInt % 2 == 0)
-      AckAction.send[IO](_.makeTextMessage("a brand new message").map(newMsg => (newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => AckAction.send((newMsg, outputTopic)))
     else if (text.toInt % 3 == 0)
-      AckAction.noAck
+      IO.pure(AckAction.noAck)
     else
-      AckAction.ack
-  }
+      IO.pure(AckAction.ack)
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
@@ -26,10 +25,10 @@ class AckConsumerExample extends IOApp {
       consumer   <- jmsClient.createAcknowledgerConsumer(jmsContext, inputQueue, 10)
     } yield consumer
 
-    consumerRes.use(_.handle { jmsMessage =>
+    consumerRes.use(_.handle { (jmsMessage, mf) =>
       for {
         text <- jmsMessage.asTextF[IO]
-        res  <- yourBusinessLogic(text)
+        res  <- yourBusinessLogic(text, mf)
       } yield res
     }.as(ExitCode.Success))
   }

--- a/examples/src/main/scala/AutoAckConsumerExample.scala
+++ b/examples/src/main/scala/AutoAckConsumerExample.scala
@@ -13,7 +13,7 @@ class AutoAckConsumerExample extends IOApp {
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AutoAckAction[IO]] =
     if (text.toInt % 2 == 0) {
-      mf.makeTextMessage("a brand new message").map(newMsg => AutoAckAction.send[IO]((newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => AutoAckAction.send[IO](newMsg, outputTopic))
     } else {
       IO.pure(AutoAckAction.noOp)
     }

--- a/examples/src/main/scala/TransactedConsumerExample.scala
+++ b/examples/src/main/scala/TransactedConsumerExample.scala
@@ -2,7 +2,7 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsClient
 import jms4s.JmsTransactedConsumer._
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.JmsContext
+import jms4s.jms.{ JmsContext, MessageFactory }
 
 class TransactedConsumerExample extends IOApp {
 
@@ -11,14 +11,12 @@ class TransactedConsumerExample extends IOApp {
   val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
   val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
 
-  def yourBusinessLogic(text: String): IO[TransactionAction[IO]] =
-    IO.delay {
-      if (text.toInt % 2 == 0)
-        TransactionAction.send[IO](_.makeTextMessage("a brand new message").map(newMsg => (newMsg, outputTopic)))
-      else if (text.toInt % 3 == 0)
-        TransactionAction.rollback
-      else TransactionAction.commit
-    }
+  def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[TransactionAction[IO]] =
+    if (text.toInt % 2 == 0)
+      mf.makeTextMessage("a brand new message").map(newMsg => TransactionAction.send((newMsg, outputTopic)))
+    else if (text.toInt % 3 == 0)
+      IO.pure(TransactionAction.rollback)
+    else IO.pure(TransactionAction.commit)
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
@@ -26,10 +24,10 @@ class TransactedConsumerExample extends IOApp {
       consumer   <- jmsClient.createTransactedConsumer(jmsContext, inputQueue, 10)
     } yield consumer
 
-    consumerRes.use(_.handle { jmsMessage =>
+    consumerRes.use(_.handle { (jmsMessage, mf) =>
       for {
         text <- jmsMessage.asTextF[IO]
-        res  <- yourBusinessLogic(text)
+        res  <- yourBusinessLogic(text, mf)
       } yield res
     }.as(ExitCode.Success))
   }

--- a/examples/src/main/scala/TransactedConsumerExample.scala
+++ b/examples/src/main/scala/TransactedConsumerExample.scala
@@ -13,7 +13,7 @@ class TransactedConsumerExample extends IOApp {
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[TransactionAction[IO]] =
     if (text.toInt % 2 == 0)
-      mf.makeTextMessage("a brand new message").map(newMsg => TransactionAction.send((newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => TransactionAction.send(newMsg, outputTopic))
     else if (text.toInt % 3 == 0)
       IO.pure(TransactionAction.rollback)
     else IO.pure(TransactionAction.commit)

--- a/site/docs/programs/ack-consumer/index.md
+++ b/site/docs/programs/ack-consumer/index.md
@@ -28,7 +28,7 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.JmsContext
+import jms4s.jms.{ JmsContext, MessageFactory }
 
 class AckConsumerExample extends IOApp {
 
@@ -37,14 +37,13 @@ class AckConsumerExample extends IOApp {
   val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
   val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
 
-  def yourBusinessLogic(text: String): IO[AckAction[IO]] = IO.delay {
+  def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AckAction[IO]] =
     if (text.toInt % 2 == 0)
-      AckAction.send[IO](_.makeTextMessage("a brand new message").map(newMsg => (newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => AckAction.send(newMsg, outputTopic))
     else if (text.toInt % 3 == 0)
-      AckAction.noAck
+      IO.pure(AckAction.noAck)
     else
-      AckAction.ack
-  }
+      IO.pure(AckAction.ack)
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
@@ -52,10 +51,10 @@ class AckConsumerExample extends IOApp {
       consumer   <- jmsClient.createAcknowledgerConsumer(jmsContext, inputQueue, 10)
     } yield consumer
 
-    consumerRes.use(_.handle { jmsMessage =>
+    consumerRes.use(_.handle { (jmsMessage, mf) =>
       for {
         text <- jmsMessage.asTextF[IO]
-        res  <- yourBusinessLogic(text)
+        res  <- yourBusinessLogic(text, mf)
       } yield res
     }.as(ExitCode.Success))
   }

--- a/site/docs/programs/auto-ack-consumer/index.md
+++ b/site/docs/programs/auto-ack-consumer/index.md
@@ -9,7 +9,7 @@ A `JmsAutoAcknowledgerConsumer` is a consumer that will automatically acknowledg
 Its only operation is:
 
 ```scala
-def handle(f: JmsMessage => F[AutoAckAction[F]]): F[Unit]
+def handle(f: (JmsMessage, MessageFactory[F]) => F[AutoAckAction[F]]): F[Unit]
 ```
 
 This is where the user of the API can specify its business logic, which can be any effectful operation.
@@ -27,7 +27,7 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.JmsContext
+import jms4s.jms.{ JmsContext, MessageFactory }
 
 class AutoAckConsumerExample extends IOApp {
 
@@ -36,12 +36,12 @@ class AutoAckConsumerExample extends IOApp {
   val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
   val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
 
-  def yourBusinessLogic(text: String): IO[AutoAckAction[IO]] = IO.delay {
-    if (text.toInt % 2 == 0)
-      AutoAckAction.send[IO](_.makeTextMessage("a brand new message").map(newMsg => (newMsg, outputTopic)))
-    else
-      AutoAckAction.noOp
-  }
+  def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AutoAckAction[IO]] =
+    if (text.toInt % 2 == 0) {
+      mf.makeTextMessage("a brand new message").map(newMsg => AutoAckAction.send[IO]((newMsg, outputTopic)))
+    } else {
+      IO.pure(AutoAckAction.noOp)
+    }
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
@@ -49,10 +49,10 @@ class AutoAckConsumerExample extends IOApp {
       consumer   <- jmsClient.createAutoAcknowledgerConsumer(jmsContext, inputQueue, 10)
     } yield consumer
 
-    consumerRes.use(_.handle { jmsMessage =>
+    consumerRes.use(_.handle { (jmsMessage, mf) =>
       for {
         text <- jmsMessage.asTextF[IO]
-        res  <- yourBusinessLogic(text)
+        res  <- yourBusinessLogic(text, mf)
       } yield res
     }.as(ExitCode.Success))
   }

--- a/site/docs/programs/auto-ack-consumer/index.md
+++ b/site/docs/programs/auto-ack-consumer/index.md
@@ -38,7 +38,7 @@ class AutoAckConsumerExample extends IOApp {
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AutoAckAction[IO]] =
     if (text.toInt % 2 == 0) {
-      mf.makeTextMessage("a brand new message").map(newMsg => AutoAckAction.send[IO]((newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => AutoAckAction.send[IO](newMsg, outputTopic))
     } else {
       IO.pure(AutoAckAction.noOp)
     }
@@ -57,5 +57,4 @@ class AutoAckConsumerExample extends IOApp {
     }.as(ExitCode.Success))
   }
 }
-
 ```

--- a/site/docs/programs/tx-consumer/index.md
+++ b/site/docs/programs/tx-consumer/index.md
@@ -9,7 +9,7 @@ A `JmsTransactedConsumer` is a consumer that will use a local transaction to rec
 Its only operation is:
 
 ```scala
-def handle(f: JmsMessage => F[TransactionAction[F]]): F[Unit]
+def handle(f: (JmsMessage, MessageFactory[F]) => F[TransactionAction[F]]): F[Unit]
 ```
 
 This is where the user of the API can specify its business logic, which can be any effectful operation.
@@ -28,7 +28,7 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsClient
 import jms4s.JmsTransactedConsumer._
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.JmsContext
+import jms4s.jms.{ JmsContext, MessageFactory }
 
 class TransactedConsumerExample extends IOApp {
 
@@ -37,14 +37,12 @@ class TransactedConsumerExample extends IOApp {
   val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
   val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
 
-  def yourBusinessLogic(text: String): IO[TransactionAction[IO]] =
-    IO.delay {
-      if (text.toInt % 2 == 0)
-        TransactionAction.send[IO](_.makeTextMessage("a brand new message").map(newMsg => (newMsg, outputTopic)))
-      else if (text.toInt % 3 == 0)
-        TransactionAction.rollback
-      else TransactionAction.commit
-    }
+  def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[TransactionAction[IO]] =
+    if (text.toInt % 2 == 0)
+      mf.makeTextMessage("a brand new message").map(newMsg => TransactionAction.send((newMsg, outputTopic)))
+    else if (text.toInt % 3 == 0)
+      IO.pure(TransactionAction.rollback)
+    else IO.pure(TransactionAction.commit)
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
@@ -52,10 +50,10 @@ class TransactedConsumerExample extends IOApp {
       consumer   <- jmsClient.createTransactedConsumer(jmsContext, inputQueue, 10)
     } yield consumer
 
-    consumerRes.use(_.handle { jmsMessage =>
+    consumerRes.use(_.handle { (jmsMessage, mf) =>
       for {
         text <- jmsMessage.asTextF[IO]
-        res  <- yourBusinessLogic(text)
+        res  <- yourBusinessLogic(text, mf)
       } yield res
     }.as(ExitCode.Success))
   }

--- a/site/docs/programs/tx-consumer/index.md
+++ b/site/docs/programs/tx-consumer/index.md
@@ -39,7 +39,7 @@ class TransactedConsumerExample extends IOApp {
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[TransactionAction[IO]] =
     if (text.toInt % 2 == 0)
-      mf.makeTextMessage("a brand new message").map(newMsg => TransactionAction.send((newMsg, outputTopic)))
+      mf.makeTextMessage("a brand new message").map(newMsg => TransactionAction.send(newMsg, outputTopic))
     else if (text.toInt % 3 == 0)
       IO.pure(TransactionAction.rollback)
     else IO.pure(TransactionAction.commit)

--- a/tests/src/test/scala/jms4s/JmsClientSpec.scala
+++ b/tests/src/test/scala/jms4s/JmsClientSpec.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Ref
 import cats.effect.testing.scalatest.AsyncIOSpec
-import cats.effect.{IO, Resource, Timer}
+import cats.effect.{ IO, Resource, Timer }
 import cats.implicits._
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
@@ -72,9 +72,9 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
                                         newm <- mf.makeTextMessage(text)
                                       } yield
                                         if (text.toInt % 2 == 0)
-                                          TransactionAction.send[IO]((newm, outputQueueName1))
+                                          TransactionAction.send[IO](newm, outputQueueName1)
                                         else
-                                          TransactionAction.send[IO]((newm, outputQueueName2))
+                                          TransactionAction.send[IO](newm, outputQueueName2)
                                     }.start
           _         <- logger.info(s"Consumer to Producer started. Collecting messages from output queues...")
           received1 <- Ref.of[IO, Set[String]](Set())
@@ -138,13 +138,13 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           _ <- logger.info(s"Pushed ${messages.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, mf) =>
                                       for {
-                                        text <- message.asTextF[IO]
+                                        text                            <- message.asTextF[IO]
                                         newm: JmsMessage.JmsTextMessage <- mf.makeTextMessage(text)
                                       } yield
                                         if (text.toInt % 2 == 0)
-                                          AckAction.send[IO]((newm, outputQueueName1))
+                                          AckAction.send[IO](newm, outputQueueName1)
                                         else
-                                          AckAction.send[IO]((newm, outputQueueName2))
+                                          AckAction.send[IO](newm, outputQueueName2)
                                     }.start
           _         <- logger.info(s"Consumer to Producer started. Collecting messages from output queues...")
           received1 <- Ref.of[IO, Set[String]](Set())
@@ -213,8 +213,8 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
                                         text <- tm.asTextF[IO]
                                       } yield
                                         if (text.toInt % 2 == 0)
-                                          AutoAckAction.send[IO]((tm, outputQueueName1))
-                                        else AutoAckAction.send[IO]((tm, outputQueueName2))
+                                          AutoAckAction.send[IO](tm, outputQueueName1)
+                                        else AutoAckAction.send[IO](tm, outputQueueName2)
                                     }.start
           _         <- logger.info(s"Consumer to Producer started. Collecting messages from output queues...")
           received1 <- Ref.of[IO, Set[String]](Set())


### PR DESCRIPTION
The previous design was not allowing us to model certain scenarios, e.g.:

```scala
    consumer.handle { msg =>
      val toSend: MessageFactory[IO] => IO[(JmsMessage, DestinationName)] = mf =>
        for {
          text   <- msg.asTextF[IO]
          newMsg <- mf.makeTextMessage(text)
          destination <- IO.fromTry(producerProvider(newMsg)) // how to catch and rollback if something fails here?!
        } yield (newMsg, destination)
      IO.pure(TransactionAction.send(toSend))
    }
```

In short
- the lib internals is not handling any error in case of message construction effect failures, so the error was then propagated
- the lib is not offering any error handler to the client

The way we changed the design is as follows:

```scala
    consumer.handle { (msg, messageFactory) =>
        val comp =  for {
          text   <- msg.asTextF[IO]
          newMsg <- mf.makeTextMessage(text)
          destination <- IO.fromTry(producerProvider(newMsg)) 
        } yield TransactionAction.send(newMsg, destination)
       comp.handleErrorWith(_ => IO.pure(TransactionAction.rollback))
    }
```

With this design:
- the message factory has been moved so that the client is now able to handle all failures explicitly
- what the lib is internally doing has been kept as it was