### PR TITLE
Do not expose JmsContext to client

### DIFF
--- a/core/src/main/scala/jms4s/JmsClient.scala
+++ b/core/src/main/scala/jms4s/JmsClient.scala
@@ -4,31 +4,27 @@ import cats.effect.{ Concurrent, ContextShift, Resource }
 import jms4s.config.DestinationName
 import jms4s.jms._
 
-class JmsClient[F[_]: ContextShift: Concurrent] {
+class JmsClient[F[_]: ContextShift: Concurrent](private[jms4s] val context: JmsContext[F]) {
 
   def createTransactedConsumer(
-    context: JmsContext[F],
     inputDestinationName: DestinationName,
     concurrencyLevel: Int
   ): Resource[F, JmsTransactedConsumer[F]] =
     JmsTransactedConsumer.make(context, inputDestinationName, concurrencyLevel)
 
   def createAutoAcknowledgerConsumer(
-    context: JmsContext[F],
     inputDestinationName: DestinationName,
     concurrencyLevel: Int
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
     JmsAutoAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel)
 
   def createAcknowledgerConsumer(
-    context: JmsContext[F],
     inputDestinationName: DestinationName,
     concurrencyLevel: Int
   ): Resource[F, JmsAcknowledgerConsumer[F]] =
     JmsAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel)
 
   def createProducer(
-    context: JmsContext[F],
     concurrencyLevel: Int
   ): Resource[F, JmsProducer[F]] =
     JmsProducer.make(context, concurrencyLevel)

--- a/core/src/main/scala/jms4s/JmsClient.scala
+++ b/core/src/main/scala/jms4s/JmsClient.scala
@@ -4,7 +4,7 @@ import cats.effect.{ Concurrent, ContextShift, Resource }
 import jms4s.config.DestinationName
 import jms4s.jms._
 
-class JmsClient[F[_]: ContextShift: Concurrent](private[jms4s] val context: JmsContext[F]) {
+class JmsClient[F[_]: ContextShift: Concurrent] private[jms4s] (private[jms4s] val context: JmsContext[F]) {
 
   def createTransactedConsumer(
     inputDestinationName: DestinationName,

--- a/examples/src/main/scala/AckConsumerExample.scala
+++ b/examples/src/main/scala/AckConsumerExample.scala
@@ -2,14 +2,13 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.{ JmsContext, MessageFactory }
+import jms4s.jms.MessageFactory
 
 class AckConsumerExample extends IOApp {
 
-  val contextRes: Resource[IO, JmsContext[IO]] = null // see providers section!
-  val jmsClient: JmsClient[IO]                 = new JmsClient[IO]
-  val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
-  val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
+  val contextRes: Resource[IO, JmsClient[IO]] = null // see providers section!
+  val inputQueue: QueueName                   = QueueName("YUOR.INPUT.QUEUE")
+  val outputTopic: TopicName                  = TopicName("YUOR.OUTPUT.TOPIC")
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AckAction[IO]] =
     if (text.toInt % 2 == 0)
@@ -21,8 +20,8 @@ class AckConsumerExample extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
-      jmsContext <- contextRes
-      consumer   <- jmsClient.createAcknowledgerConsumer(jmsContext, inputQueue, 10)
+      client   <- contextRes
+      consumer <- client.createAcknowledgerConsumer(inputQueue, 10)
     } yield consumer
 
     consumerRes.use(_.handle { (jmsMessage, mf) =>

--- a/examples/src/main/scala/AutoAckConsumerExample.scala
+++ b/examples/src/main/scala/AutoAckConsumerExample.scala
@@ -2,14 +2,13 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.{ JmsContext, MessageFactory }
+import jms4s.jms.MessageFactory
 
 class AutoAckConsumerExample extends IOApp {
 
-  val contextRes: Resource[IO, JmsContext[IO]] = null // see providers section!
-  val jmsClient: JmsClient[IO]                 = new JmsClient[IO]
-  val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
-  val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
+  val jmsClient: Resource[IO, JmsClient[IO]] = null // see providers section!
+  val inputQueue: QueueName                  = QueueName("YUOR.INPUT.QUEUE")
+  val outputTopic: TopicName                 = TopicName("YUOR.OUTPUT.TOPIC")
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[AutoAckAction[IO]] =
     if (text.toInt % 2 == 0) {
@@ -20,8 +19,8 @@ class AutoAckConsumerExample extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
-      jmsContext <- contextRes
-      consumer   <- jmsClient.createAutoAcknowledgerConsumer(jmsContext, inputQueue, 10)
+      client   <- jmsClient
+      consumer <- client.createAutoAcknowledgerConsumer(inputQueue, 10)
     } yield consumer
 
     consumerRes.use(_.handle { (jmsMessage, mf) =>

--- a/examples/src/main/scala/ProducerExample.scala
+++ b/examples/src/main/scala/ProducerExample.scala
@@ -3,22 +3,21 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsClient
 import jms4s.config.{ DestinationName, TopicName }
 import jms4s.jms.JmsMessage.JmsTextMessage
-import jms4s.jms.{ JmsContext, MessageFactory }
+import jms4s.jms.MessageFactory
 
 import scala.concurrent.duration.{ FiniteDuration, _ }
 
 class ProducerExample extends IOApp {
 
-  val contextRes: Resource[IO, JmsContext[IO]] = null // see providers section!
-  val jmsClient: JmsClient[IO]                 = new JmsClient[IO]
-  val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
-  val delay: FiniteDuration                    = 10.millis
-  val messageStrings: NonEmptyList[String]     = NonEmptyList.fromListUnsafe((0 until 10).map(i => s"$i").toList)
+  val jmsClient: Resource[IO, JmsClient[IO]] = null // see providers section!
+  val outputTopic: TopicName                 = TopicName("YUOR.OUTPUT.TOPIC")
+  val delay: FiniteDuration                  = 10.millis
+  val messageStrings: NonEmptyList[String]   = NonEmptyList.fromListUnsafe((0 until 10).map(i => s"$i").toList)
 
   override def run(args: List[String]): IO[ExitCode] = {
     val producerRes = for {
-      jmsContext <- contextRes
-      producer   <- jmsClient.createProducer(jmsContext, 10)
+      client   <- jmsClient
+      producer <- client.createProducer(10)
     } yield producer
 
     producerRes.use { producer =>

--- a/examples/src/main/scala/TransactedConsumerExample.scala
+++ b/examples/src/main/scala/TransactedConsumerExample.scala
@@ -2,14 +2,13 @@ import cats.effect.{ ExitCode, IO, IOApp, Resource }
 import jms4s.JmsClient
 import jms4s.JmsTransactedConsumer._
 import jms4s.config.{ QueueName, TopicName }
-import jms4s.jms.{ JmsContext, MessageFactory }
+import jms4s.jms.MessageFactory
 
 class TransactedConsumerExample extends IOApp {
 
-  val contextRes: Resource[IO, JmsContext[IO]] = null // see providers section!
-  val jmsClient: JmsClient[IO]                 = new JmsClient[IO]
-  val inputQueue: QueueName                    = QueueName("YUOR.INPUT.QUEUE")
-  val outputTopic: TopicName                   = TopicName("YUOR.OUTPUT.TOPIC")
+  val jmsClient: Resource[IO, JmsClient[IO]] = null // see providers section!
+  val inputQueue: QueueName                  = QueueName("YUOR.INPUT.QUEUE")
+  val outputTopic: TopicName                 = TopicName("YUOR.OUTPUT.TOPIC")
 
   def yourBusinessLogic(text: String, mf: MessageFactory[IO]): IO[TransactionAction[IO]] =
     if (text.toInt % 2 == 0)
@@ -20,8 +19,8 @@ class TransactedConsumerExample extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
-      jmsContext <- contextRes
-      consumer   <- jmsClient.createTransactedConsumer(jmsContext, inputQueue, 10)
+      client   <- jmsClient
+      consumer <- client.createTransactedConsumer(inputQueue, 10)
     } yield consumer
 
     consumerRes.use(_.handle { (jmsMessage, mf) =>

--- a/site/docs/providers/active-mq-artemis/index.md
+++ b/site/docs/providers/active-mq-artemis/index.md
@@ -18,7 +18,7 @@ override def contextRes(implicit cs: ContextShift[IO]): Resource[IO, JmsContext[
   Blocker
     .apply[IO]
     .flatMap(blocker =>
-      activeMQ.makeContext[IO](
+      activeMQ.makeJmsClient[IO](
         Config(
           endpoints = NonEmptyList.one(Endpoint("localhost", 61616)),
           username = Some(Username("YOU")),

--- a/site/docs/providers/ibm-mq/index.md
+++ b/site/docs/providers/ibm-mq/index.md
@@ -18,7 +18,7 @@ def contextRes(implicit cs: ContextShift[IO]): Resource[IO, JmsContext[IO]] =
   Blocker
     .apply[IO]
     .flatMap(blocker =>
-      ibmMQ.makeContext[IO](
+      ibmMQ.makeJmsClient[IO](
         Config(
           qm = QueueManager("YOUR.QM"),
           endpoints = NonEmptyList.one(Endpoint("localhost", 1414)),

--- a/tests/src/test/scala/jms4s/JmsClientSpec.scala
+++ b/tests/src/test/scala/jms4s/JmsClientSpec.scala
@@ -4,34 +4,29 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Ref
 import cats.effect.testing.scalatest.AsyncIOSpec
-import cats.effect.{ IO, Resource, Timer }
+import cats.effect.{ IO, Timer }
 import cats.implicits._
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.JmsTransactedConsumer.TransactionAction
 import jms4s.basespec.Jms4sBaseSpec
-import jms4s.jms.JmsMessage
-import jms4s.model.SessionType
 import org.scalatest.freespec.AsyncFreeSpec
-
 import scala.concurrent.duration._
 
 trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
-  private val jmsClient = new JmsClient[IO]
 
   s"publish $nMessages messages and then consume them concurrently with local transactions" in {
     val res = for {
-      context     <- contextRes
-      consumer    <- jmsClient.createTransactedConsumer(context, inputQueueName, poolSize)
-      sendContext <- context.createContext(SessionType.AutoAcknowledge)
-      messages    <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-    } yield (consumer, sendContext, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
+      producwr  <- jmsClient.createProducer(poolSize)
+    } yield (consumer, producwr, bodies.toSet)
 
     res.use {
-      case (consumer, context, bodies, messages) =>
+      case (consumer, producer, bodies) =>
         for {
-          _        <- messages.traverse_(msg => context.send(inputQueueName, msg))
-          _        <- logger.info(s"Pushed ${messages.size} messages.")
+          _        <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
+          _        <- logger.info(s"Pushed ${bodies.size} messages.")
           received <- Ref.of[IO, Set[String]](Set())
           consumerFiber <- consumer.handle { (message, _) =>
                             for {
@@ -49,23 +44,18 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages, consume them concurrently with local transactions and then republishing to other queues" in {
 
     val res = for {
-      context <- contextRes
-      consumer <- jmsClient.createTransactedConsumer(
-                   context,
-                   inputQueueName,
-                   poolSize
-                 )
-      sendContext <- context.createContext(SessionType.AutoAcknowledge)
-      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
-      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
-    } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
+      producwr  <- jmsClient.createProducer(poolSize)
+      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
+    } yield (consumer, producwr, consumer1, consumer2, bodies.toSet)
 
     res.use {
-      case (consumer, sendContext, consumer1, consumer2, bodies, messages) =>
+      case (consumer, producer, consumer1, consumer2, bodies) =>
         for {
-          _ <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
-          _ <- logger.info(s"Pushed ${messages.size} messages.")
+          _ <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
+          _ <- logger.info(s"Pushed ${bodies.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, mf) =>
                                       for {
                                         text <- message.asTextF[IO]
@@ -80,9 +70,9 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           received1 <- Ref.of[IO, Set[String]](Set())
           received2 <- Ref.of[IO, Set[String]](Set())
           receivedMessages <- ((
-                               receiveUntil(consumer1, received1, nMessages / 2),
-                               receiveUntil(consumer2, received2, nMessages / 2)
-                             ).parTupled.timeout(timeout) >> (received1.get, received2.get).mapN(_ ++ _))
+                               receiveUntil(consumer1, received1, nMessages / 2, timeout),
+                               receiveUntil(consumer2, received2, nMessages / 2, timeout)
+                             ).parTupled >> (received1.get, received2.get).mapN(_ ++ _))
                                .guarantee(consumerToProducerFiber.cancel)
         } yield assert(receivedMessages == bodies)
     }
@@ -91,17 +81,16 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages and then consume them concurrently with acknowledge" in {
 
     val res = for {
-      context     <- contextRes
-      consumer    <- jmsClient.createAcknowledgerConsumer(context, inputQueueName, poolSize)
-      sendContext <- context.createContext(SessionType.AutoAcknowledge)
-      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
-    } yield (consumer, sendContext, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (consumer, producer, bodies.toSet)
 
     res.use {
-      case (consumer, sendContext, bodies, messages) =>
+      case (consumer, producer, bodies) =>
         for {
-          _        <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
-          _        <- logger.info(s"Pushed ${messages.size} messages.")
+          _        <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
+          _        <- logger.info(s"Pushed ${bodies.size} messages.")
           received <- Ref.of[IO, Set[String]](Set())
           consumerFiber <- consumer.handle { (message, _) =>
                             for {
@@ -119,27 +108,22 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages, consume them concurrently and then republishing to other queues, with acknowledge" in {
 
     val res = for {
-      context <- contextRes
-      consumer <- jmsClient.createAcknowledgerConsumer(
-                   context,
-                   inputQueueName,
-                   poolSize
-                 )
-      sendContext <- context.createContext(SessionType.AutoAcknowledge)
-      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
-      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
-    } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
+    } yield (consumer, producer, consumer1, consumer2, bodies.toSet)
 
     res.use {
-      case (consumer, sendContext, consumer1, consumer2, bodies, messages) =>
+      case (consumer, producer, consumer1, consumer2, bodies) =>
         for {
-          _ <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
-          _ <- logger.info(s"Pushed ${messages.size} messages.")
+          _ <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
+          _ <- logger.info(s"Pushed ${bodies.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, mf) =>
                                       for {
-                                        text                            <- message.asTextF[IO]
-                                        newm: JmsMessage.JmsTextMessage <- mf.makeTextMessage(text)
+                                        text <- message.asTextF[IO]
+                                        newm <- mf.makeTextMessage(text)
                                       } yield
                                         if (text.toInt % 2 == 0)
                                           AckAction.send[IO](newm, outputQueueName1)
@@ -150,8 +134,8 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           received1 <- Ref.of[IO, Set[String]](Set())
           received2 <- Ref.of[IO, Set[String]](Set())
           receivedMessages <- ((
-                               receiveUntil(consumer1, received1, nMessages / 2),
-                               receiveUntil(consumer2, received2, nMessages / 2)
+                               receiveUntil(consumer1, received1, nMessages / 2, timeout),
+                               receiveUntil(consumer2, received2, nMessages / 2, timeout)
                              ).parTupled.timeout(timeout) >> (received1.get, received2.get).mapN(_ ++ _))
                                .guarantee(consumerToProducerFiber.cancel)
         } yield assert(receivedMessages == bodies)
@@ -161,17 +145,16 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages and then consume them concurrently with auto-acknowledge" in {
 
     val res = for {
-      context     <- contextRes
-      consumer    <- jmsClient.createAutoAcknowledgerConsumer(context, inputQueueName, poolSize)
-      sendContext <- context.createContext(SessionType.AutoAcknowledge)
-      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
-    } yield (consumer, sendContext, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (consumer, producer, bodies.toSet)
 
     res.use {
-      case (consumer, sendContext, bodies, messages) =>
+      case (consumer, producer, bodies) =>
         for {
-          _        <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
-          _        <- logger.info(s"Pushed ${messages.size} messages.")
+          _        <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
+          _        <- logger.info(s"Pushed ${bodies.size} messages.")
           received <- Ref.of[IO, Set[String]](Set())
           consumerFiber <- consumer.handle { (message, _) =>
                             for {
@@ -189,24 +172,19 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages, consume them concurrently and then republishing to other queues, with auto-acknowledge" in {
 
     val res = for {
-      context <- contextRes
-      consumer <- jmsClient.createAutoAcknowledgerConsumer(
-                   context,
-                   inputQueueName,
-                   poolSize
-                 )
-      sendContext <- context.createContext(SessionType.AutoAcknowledge)
-      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
-      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
 
-    } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
+    } yield (consumer, producer, consumer1, consumer2, bodies.toSet)
 
     res.use {
-      case (consumer, sendContext, consumer1, consumer2, bodies, messages) =>
+      case (consumer, producer, consumer1, consumer2, bodies) =>
         for {
-          _ <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
-          _ <- logger.info(s"Pushed ${messages.size} messages.")
+          _ <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
+          _ <- logger.info(s"Pushed ${bodies.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, _) =>
                                       for {
                                         tm   <- message.asJmsTextMessageF[IO]
@@ -220,9 +198,9 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           received1 <- Ref.of[IO, Set[String]](Set())
           received2 <- Ref.of[IO, Set[String]](Set())
           receivedMessages <- ((
-                               receiveUntil(consumer1, received1, nMessages / 2),
-                               receiveUntil(consumer2, received2, nMessages / 2)
-                             ).parTupled.timeout(timeout) >> (received1.get, received2.get).mapN(_ ++ _))
+                               receiveUntil(consumer1, received1, nMessages / 2, timeout),
+                               receiveUntil(consumer2, received2, nMessages / 2, timeout)
+                             ).parTupled >> (received1.get, received2.get).mapN(_ ++ _))
                                .guarantee(consumerToProducerFiber.cancel)
         } yield assert(receivedMessages == bodies)
     }
@@ -231,20 +209,19 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"send $nMessages messages in a Queue with pooled producer and consume them" in {
 
     val res = for {
-      context  <- contextRes
-      consumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      messages <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-      producer <- jmsClient.createProducer(context, poolSize)
-    } yield (producer, consumer, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (producer, consumer, bodies.toSet)
 
     res.use {
-      case (producer, consumer, bodies, messages) =>
+      case (producer, consumer, bodies) =>
         for {
-          _                <- messages.parTraverse_(msg => producer.send(messageFactory(msg, outputQueueName1)))
-          _                <- logger.info(s"Pushed ${messages.size} messages.")
+          _                <- producer.sendN(messageFactory(bodies.toList, outputQueueName1))
+          _                <- logger.info(s"Pushed ${bodies.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -252,20 +229,19 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"sendN $nMessages messages in a Queue with pooled producer and consume them" in {
 
     val res = for {
-      context  <- contextRes
-      consumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      messages <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-      producer <- jmsClient.createProducer(context, poolSize)
-    } yield (producer, consumer, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (producer, consumer, bodies.toSet)
 
     res.use {
-      case (producer, consumer, bodies, messages) =>
+      case (producer, consumer, bodies) =>
         for {
-          _                <- messages.toNel.traverse_(msg => producer.sendN(messageFactory(msg, outputQueueName1)))
-          _                <- logger.info(s"Pushed ${messages.size} messages.")
+          _                <- producer.sendN(messageFactory(bodies.toList, outputQueueName1))
+          _                <- logger.info(s"Pushed ${bodies.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -273,20 +249,19 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"send $nMessages messages in a Topic with pooled producer and consume them" in {
 
     val res = for {
-      context  <- contextRes
-      consumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
-      messages <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-      producer <- jmsClient.createProducer(context, poolSize)
-    } yield (producer, consumer, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(topicName1, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (producer, consumer, bodies.toSet)
 
     res.use {
-      case (producer, consumer, bodies, messages) =>
+      case (producer, consumer, bodies) =>
         for {
-          _                <- messages.parTraverse_(msg => producer.send(messageFactory(msg, topicName1)))
-          _                <- logger.info(s"Pushed ${messages.size} messages.")
+          _                <- producer.sendN(messageFactory(bodies.toList, topicName1))
+          _                <- logger.info(s"Pushed ${bodies.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -294,20 +269,19 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"sendN $nMessages messages in a Topic with pooled producer and consume them" in {
 
     val res = for {
-      context  <- contextRes
-      consumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
-      messages <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-      producer <- jmsClient.createProducer(context, poolSize)
-    } yield (producer, consumer, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(topicName1, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (producer, consumer, bodies.toSet)
 
     res.use {
-      case (producer, consumer, bodies, messages) =>
+      case (producer, consumer, bodies) =>
         for {
-          _                <- messages.toNel.fold(IO.unit)(ms => producer.sendN(messageFactory(ms, topicName1)))
-          _                <- logger.info(s"Pushed ${messages.size} messages.")
+          _                <- producer.sendN(messageFactory(bodies.toList, topicName1))
+          _                <- logger.info(s"Pushed ${bodies.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -315,29 +289,24 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"send $nMessages messages in two Queues with pooled producer and consume them" in {
 
     val res = for {
-      context   <- contextRes
-      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-      producer  <- jmsClient.createProducer(context, poolSize)
-      consumer1 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
-    } yield (producer, consumer1, consumer2, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      producer  <- jmsClient.createProducer(poolSize)
+      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
+    } yield (producer, consumer1, consumer2, bodies.toSet)
 
     res.use {
-      case (producer, consumer1, consumer2, bodies, messages) =>
+      case (producer, consumer1, consumer2, bodies) =>
         for {
-          _ <- messages.parTraverse_(msg =>
-                producer.send(messageFactory(msg, outputQueueName1)) *> producer.send(
-                  messageFactory(msg, outputQueueName2)
-                )
+          _ <- producer.sendN(messageFactory(bodies.toList, outputQueueName1)) *> producer.sendN(
+                messageFactory(bodies.toList, outputQueueName2)
               )
-          _                  <- logger.info(s"Pushed ${messages.size} messages.")
-          _                  <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
-          firstBatch         <- Ref.of[IO, Set[String]](Set())
-          firstBatchMessages <- receiveUntil(consumer1, firstBatch, nMessages).timeout(timeout) >> firstBatch.get
-          secondBatch        <- Ref.of[IO, Set[String]](Set())
-          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages).timeout(
-                                  timeout
-                                ) >> secondBatch.get
+          _                   <- logger.info(s"Pushed ${bodies.size} messages.")
+          _                   <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
+          firstBatch          <- Ref.of[IO, Set[String]](Set())
+          firstBatchMessages  <- receiveUntil(consumer1, firstBatch, nMessages, timeout) >> firstBatch.get
+          secondBatch         <- Ref.of[IO, Set[String]](Set())
+          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages, timeout) >> secondBatch.get
         } yield assert(firstBatchMessages == bodies && secondBatchMessages == bodies)
     }
   }
@@ -345,49 +314,46 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"send $nMessages messages in two Topics with pooled producer and consume them" in {
 
     val res = for {
-      context   <- contextRes
-      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
-      producer  <- jmsClient.createProducer(context, poolSize)
-      consumer1 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
-      consumer2 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName2))
-    } yield (producer, consumer1, consumer2, bodies.toSet, messages)
+      jmsClient <- jmsClientRes
+      producer  <- jmsClient.createProducer(poolSize)
+      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(topicName1, poolSize)
+      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(topicName2, poolSize)
+    } yield (producer, consumer1, consumer2, bodies.toSet)
 
     res.use {
-      case (producer, consumer1, consumer2, bodies, messages) =>
+      case (producer, consumer1, consumer2, bodies) =>
         for {
-          _ <- messages.parTraverse_(msg =>
-                producer.send(messageFactory(msg, topicName1)) *> producer.send(messageFactory(msg, topicName2))
+          _ <- producer.sendN(messageFactory(bodies.toList, topicName1)) *> producer.sendN(
+                messageFactory(bodies.toList, topicName2)
               )
-          _                   <- logger.info(s"Pushed ${messages.size} messages.")
+          _                   <- logger.info(s"Pushed ${bodies.size} messages.")
           _                   <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
           firstBatch          <- Ref.of[IO, Set[String]](Set())
-          firstBatchMessages  <- receiveUntil(consumer1, firstBatch, nMessages).timeout(timeout) >> firstBatch.get
+          firstBatchMessages  <- receiveUntil(consumer1, firstBatch, nMessages, timeout) >> firstBatch.get
           secondBatch         <- Ref.of[IO, Set[String]](Set())
-          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages).timeout(timeout) >> secondBatch.get
+          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages, timeout) >> secondBatch.get
         } yield assert(firstBatchMessages == bodies && secondBatchMessages == bodies)
     }
   }
 
   s"sendN $nMessages messages with delay in a Queue with pooled producer and consume them" in {
     val res = for {
-      context  <- contextRes
-      consumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      message  <- Resource.liftF(context.createTextMessage(body))
-      producer <- jmsClient.createProducer(context, poolSize)
-    } yield (producer, consumer, message)
+      jmsClient <- jmsClientRes
+      consumer  <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      producer  <- jmsClient.createProducer(poolSize)
+    } yield (producer, consumer)
 
     res.use {
-      case (producer, consumer, message) =>
+      case (producer, consumer) =>
         for {
           producerTimestamp <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
-          _                 <- producer.sendWithDelay(messageWithDelayFactory((message, (outputQueueName1, Some(delay)))))
+          _                 <- producer.sendWithDelay(messageWithDelayFactory((body, (outputQueueName1, Some(delay)))))
           _                 <- logger.info(s"Pushed message with body: $body.")
           _                 <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
-          receivedMessage   <- receiveMessage(consumer).timeout(timeout)
+          text              <- receive(consumer, timeout)
           deliveryTime      <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
-          actualBody        <- receivedMessage.asTextF[IO]
           actualDelay       = (deliveryTime - producerTimestamp).millis
-        } yield assert(actualDelay >= delayWithTolerance && actualBody == body)
+        } yield assert(actualDelay >= delayWithTolerance && text == body)
     }
   }
 }

--- a/tests/src/test/scala/jms4s/JmsClientSpec.scala
+++ b/tests/src/test/scala/jms4s/JmsClientSpec.scala
@@ -4,29 +4,34 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.concurrent.Ref
 import cats.effect.testing.scalatest.AsyncIOSpec
-import cats.effect.{ IO, Timer }
+import cats.effect.{ IO, Resource, Timer }
 import cats.implicits._
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.JmsTransactedConsumer.TransactionAction
 import jms4s.basespec.Jms4sBaseSpec
+import jms4s.jms.JmsMessage
+import jms4s.model.SessionType
 import org.scalatest.freespec.AsyncFreeSpec
+
 import scala.concurrent.duration._
 
 trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
   s"publish $nMessages messages and then consume them concurrently with local transactions" in {
     val res = for {
-      jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
-      producwr  <- jmsClient.createProducer(poolSize)
-    } yield (consumer, producwr, bodies.toSet)
+      jmsClient   <- jmsClientRes
+      context     = jmsClient.context
+      consumer    <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      messages    <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
+    } yield (consumer, sendContext, bodies.toSet, messages)
 
     res.use {
-      case (consumer, producer, bodies) =>
+      case (consumer, context, bodies, messages) =>
         for {
-          _        <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
-          _        <- logger.info(s"Pushed ${bodies.size} messages.")
+          _        <- messages.traverse_(msg => context.send(inputQueueName, msg))
+          _        <- logger.info(s"Pushed ${messages.size} messages.")
           received <- Ref.of[IO, Set[String]](Set())
           consumerFiber <- consumer.handle { (message, _) =>
                             for {
@@ -44,18 +49,20 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages, consume them concurrently with local transactions and then republishing to other queues" in {
 
     val res = for {
-      jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
-      producwr  <- jmsClient.createProducer(poolSize)
-      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
-      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
-    } yield (consumer, producwr, consumer1, consumer2, bodies.toSet)
+      jmsClient   <- jmsClientRes
+      context     = jmsClient.context
+      consumer    <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
+      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+    } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
-      case (consumer, producer, consumer1, consumer2, bodies) =>
+      case (consumer, sendContext, consumer1, consumer2, bodies, messages) =>
         for {
-          _ <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
-          _ <- logger.info(s"Pushed ${bodies.size} messages.")
+          _ <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
+          _ <- logger.info(s"Pushed ${messages.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, mf) =>
                                       for {
                                         text <- message.asTextF[IO]
@@ -70,9 +77,9 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           received1 <- Ref.of[IO, Set[String]](Set())
           received2 <- Ref.of[IO, Set[String]](Set())
           receivedMessages <- ((
-                               receiveUntil(consumer1, received1, nMessages / 2, timeout),
-                               receiveUntil(consumer2, received2, nMessages / 2, timeout)
-                             ).parTupled >> (received1.get, received2.get).mapN(_ ++ _))
+                               receiveUntil(consumer1, received1, nMessages / 2),
+                               receiveUntil(consumer2, received2, nMessages / 2)
+                             ).parTupled.timeout(timeout) >> (received1.get, received2.get).mapN(_ ++ _))
                                .guarantee(consumerToProducerFiber.cancel)
         } yield assert(receivedMessages == bodies)
     }
@@ -81,16 +88,18 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages and then consume them concurrently with acknowledge" in {
 
     val res = for {
-      jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
-      producer  <- jmsClient.createProducer(poolSize)
-    } yield (consumer, producer, bodies.toSet)
+      jmsClient   <- jmsClientRes
+      context     = jmsClient.context
+      consumer    <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
+    } yield (consumer, sendContext, bodies.toSet, messages)
 
     res.use {
-      case (consumer, producer, bodies) =>
+      case (consumer, sendContext, bodies, messages) =>
         for {
-          _        <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
-          _        <- logger.info(s"Pushed ${bodies.size} messages.")
+          _        <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
+          _        <- logger.info(s"Pushed ${messages.size} messages.")
           received <- Ref.of[IO, Set[String]](Set())
           consumerFiber <- consumer.handle { (message, _) =>
                             for {
@@ -108,22 +117,24 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages, consume them concurrently and then republishing to other queues, with acknowledge" in {
 
     val res = for {
-      jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
-      producer  <- jmsClient.createProducer(poolSize)
-      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
-      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
-    } yield (consumer, producer, consumer1, consumer2, bodies.toSet)
+      jmsClient   <- jmsClientRes
+      context     = jmsClient.context
+      consumer    <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
+      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+    } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
-      case (consumer, producer, consumer1, consumer2, bodies) =>
+      case (consumer, sendContext, consumer1, consumer2, bodies, messages) =>
         for {
-          _ <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
-          _ <- logger.info(s"Pushed ${bodies.size} messages.")
+          _ <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
+          _ <- logger.info(s"Pushed ${messages.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, mf) =>
                                       for {
-                                        text <- message.asTextF[IO]
-                                        newm <- mf.makeTextMessage(text)
+                                        text                            <- message.asTextF[IO]
+                                        newm: JmsMessage.JmsTextMessage <- mf.makeTextMessage(text)
                                       } yield
                                         if (text.toInt % 2 == 0)
                                           AckAction.send[IO](newm, outputQueueName1)
@@ -134,8 +145,8 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           received1 <- Ref.of[IO, Set[String]](Set())
           received2 <- Ref.of[IO, Set[String]](Set())
           receivedMessages <- ((
-                               receiveUntil(consumer1, received1, nMessages / 2, timeout),
-                               receiveUntil(consumer2, received2, nMessages / 2, timeout)
+                               receiveUntil(consumer1, received1, nMessages / 2),
+                               receiveUntil(consumer2, received2, nMessages / 2)
                              ).parTupled.timeout(timeout) >> (received1.get, received2.get).mapN(_ ++ _))
                                .guarantee(consumerToProducerFiber.cancel)
         } yield assert(receivedMessages == bodies)
@@ -145,16 +156,18 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages and then consume them concurrently with auto-acknowledge" in {
 
     val res = for {
-      jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
-      producer  <- jmsClient.createProducer(poolSize)
-    } yield (consumer, producer, bodies.toSet)
+      jmsClient   <- jmsClientRes
+      context     = jmsClient.context
+      consumer    <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
+    } yield (consumer, sendContext, bodies.toSet, messages)
 
     res.use {
-      case (consumer, producer, bodies) =>
+      case (consumer, sendContext, bodies, messages) =>
         for {
-          _        <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
-          _        <- logger.info(s"Pushed ${bodies.size} messages.")
+          _        <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
+          _        <- logger.info(s"Pushed ${messages.size} messages.")
           received <- Ref.of[IO, Set[String]](Set())
           consumerFiber <- consumer.handle { (message, _) =>
                             for {
@@ -172,19 +185,21 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"publish $nMessages messages, consume them concurrently and then republishing to other queues, with auto-acknowledge" in {
 
     val res = for {
-      jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
-      producer  <- jmsClient.createProducer(poolSize)
-      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
-      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
+      jmsClient   <- jmsClientRes
+      context     = jmsClient.context
+      consumer    <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      messages    <- Resource.liftF(bodies.traverse(i => sendContext.createTextMessage(i)))
+      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
 
-    } yield (consumer, producer, consumer1, consumer2, bodies.toSet)
+    } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
-      case (consumer, producer, consumer1, consumer2, bodies) =>
+      case (consumer, sendContext, consumer1, consumer2, bodies, messages) =>
         for {
-          _ <- producer.sendN(messageFactory(bodies.toList, inputQueueName))
-          _ <- logger.info(s"Pushed ${bodies.size} messages.")
+          _ <- messages.traverse_(msg => sendContext.send(inputQueueName, msg))
+          _ <- logger.info(s"Pushed ${messages.size} messages.")
           consumerToProducerFiber <- consumer.handle { (message, _) =>
                                       for {
                                         tm   <- message.asJmsTextMessageF[IO]
@@ -198,9 +213,9 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
           received1 <- Ref.of[IO, Set[String]](Set())
           received2 <- Ref.of[IO, Set[String]](Set())
           receivedMessages <- ((
-                               receiveUntil(consumer1, received1, nMessages / 2, timeout),
-                               receiveUntil(consumer2, received2, nMessages / 2, timeout)
-                             ).parTupled >> (received1.get, received2.get).mapN(_ ++ _))
+                               receiveUntil(consumer1, received1, nMessages / 2),
+                               receiveUntil(consumer2, received2, nMessages / 2)
+                             ).parTupled.timeout(timeout) >> (received1.get, received2.get).mapN(_ ++ _))
                                .guarantee(consumerToProducerFiber.cancel)
         } yield assert(receivedMessages == bodies)
     }
@@ -210,18 +225,20 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
     val res = for {
       jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      context   = jmsClient.context
+      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-    } yield (producer, consumer, bodies.toSet)
+    } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
-      case (producer, consumer, bodies) =>
+      case (producer, consumer, bodies, messages) =>
         for {
-          _                <- producer.sendN(messageFactory(bodies.toList, outputQueueName1))
-          _                <- logger.info(s"Pushed ${bodies.size} messages.")
+          _                <- messages.parTraverse_(msg => producer.send(messageFactory(msg, outputQueueName1)))
+          _                <- logger.info(s"Pushed ${messages.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -230,18 +247,20 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
     val res = for {
       jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      context   = jmsClient.context
+      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-    } yield (producer, consumer, bodies.toSet)
+    } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
-      case (producer, consumer, bodies) =>
+      case (producer, consumer, bodies, messages) =>
         for {
-          _                <- producer.sendN(messageFactory(bodies.toList, outputQueueName1))
-          _                <- logger.info(s"Pushed ${bodies.size} messages.")
+          _                <- messages.toNel.traverse_(msg => producer.sendN(messageFactory(msg, outputQueueName1)))
+          _                <- logger.info(s"Pushed ${messages.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -250,18 +269,20 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
     val res = for {
       jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(topicName1, poolSize)
+      context   = jmsClient.context
+      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
+      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-    } yield (producer, consumer, bodies.toSet)
+    } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
-      case (producer, consumer, bodies) =>
+      case (producer, consumer, bodies, messages) =>
         for {
-          _                <- producer.sendN(messageFactory(bodies.toList, topicName1))
-          _                <- logger.info(s"Pushed ${bodies.size} messages.")
+          _                <- messages.parTraverse_(msg => producer.send(messageFactory(msg, topicName1)))
+          _                <- logger.info(s"Pushed ${messages.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -270,18 +291,20 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
     val res = for {
       jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(topicName1, poolSize)
+      context   = jmsClient.context
+      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
+      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-    } yield (producer, consumer, bodies.toSet)
+    } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
-      case (producer, consumer, bodies) =>
+      case (producer, consumer, bodies, messages) =>
         for {
-          _                <- producer.sendN(messageFactory(bodies.toList, topicName1))
-          _                <- logger.info(s"Pushed ${bodies.size} messages.")
+          _                <- messages.toNel.fold(IO.unit)(ms => producer.sendN(messageFactory(ms, topicName1)))
+          _                <- logger.info(s"Pushed ${messages.size} messages.")
           _                <- logger.info(s"Consumer to Producer started.\nCollecting messages from output queue...")
           received         <- Ref.of[IO, Set[String]](Set())
-          receivedMessages <- receiveUntil(consumer, received, nMessages, timeout) >> received.get
+          receivedMessages <- receiveUntil(consumer, received, nMessages).timeout(timeout) >> received.get
         } yield assert(receivedMessages == bodies)
     }
   }
@@ -290,23 +313,29 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
     val res = for {
       jmsClient <- jmsClientRes
+      context   = jmsClient.context
+      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
-      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName2, poolSize)
-    } yield (producer, consumer1, consumer2, bodies.toSet)
+      consumer1 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      consumer2 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+    } yield (producer, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
-      case (producer, consumer1, consumer2, bodies) =>
+      case (producer, consumer1, consumer2, bodies, messages) =>
         for {
-          _ <- producer.sendN(messageFactory(bodies.toList, outputQueueName1)) *> producer.sendN(
-                messageFactory(bodies.toList, outputQueueName2)
+          _ <- messages.parTraverse_(msg =>
+                producer.send(messageFactory(msg, outputQueueName1)) *> producer.send(
+                  messageFactory(msg, outputQueueName2)
+                )
               )
-          _                   <- logger.info(s"Pushed ${bodies.size} messages.")
-          _                   <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
-          firstBatch          <- Ref.of[IO, Set[String]](Set())
-          firstBatchMessages  <- receiveUntil(consumer1, firstBatch, nMessages, timeout) >> firstBatch.get
-          secondBatch         <- Ref.of[IO, Set[String]](Set())
-          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages, timeout) >> secondBatch.get
+          _                  <- logger.info(s"Pushed ${messages.size} messages.")
+          _                  <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
+          firstBatch         <- Ref.of[IO, Set[String]](Set())
+          firstBatchMessages <- receiveUntil(consumer1, firstBatch, nMessages).timeout(timeout) >> firstBatch.get
+          secondBatch        <- Ref.of[IO, Set[String]](Set())
+          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages).timeout(
+                                  timeout
+                                ) >> secondBatch.get
         } yield assert(firstBatchMessages == bodies && secondBatchMessages == bodies)
     }
   }
@@ -315,23 +344,25 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
     val res = for {
       jmsClient <- jmsClientRes
+      context   = jmsClient.context
+      messages  <- Resource.liftF(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-      consumer1 <- jmsClient.createAutoAcknowledgerConsumer(topicName1, poolSize)
-      consumer2 <- jmsClient.createAutoAcknowledgerConsumer(topicName2, poolSize)
-    } yield (producer, consumer1, consumer2, bodies.toSet)
+      consumer1 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
+      consumer2 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName2))
+    } yield (producer, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
-      case (producer, consumer1, consumer2, bodies) =>
+      case (producer, consumer1, consumer2, bodies, messages) =>
         for {
-          _ <- producer.sendN(messageFactory(bodies.toList, topicName1)) *> producer.sendN(
-                messageFactory(bodies.toList, topicName2)
+          _ <- messages.parTraverse_(msg =>
+                producer.send(messageFactory(msg, topicName1)) *> producer.send(messageFactory(msg, topicName2))
               )
-          _                   <- logger.info(s"Pushed ${bodies.size} messages.")
+          _                   <- logger.info(s"Pushed ${messages.size} messages.")
           _                   <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
           firstBatch          <- Ref.of[IO, Set[String]](Set())
-          firstBatchMessages  <- receiveUntil(consumer1, firstBatch, nMessages, timeout) >> firstBatch.get
+          firstBatchMessages  <- receiveUntil(consumer1, firstBatch, nMessages).timeout(timeout) >> firstBatch.get
           secondBatch         <- Ref.of[IO, Set[String]](Set())
-          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages, timeout) >> secondBatch.get
+          secondBatchMessages <- receiveUntil(consumer2, secondBatch, nMessages).timeout(timeout) >> secondBatch.get
         } yield assert(firstBatchMessages == bodies && secondBatchMessages == bodies)
     }
   }
@@ -339,21 +370,24 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
   s"sendN $nMessages messages with delay in a Queue with pooled producer and consume them" in {
     val res = for {
       jmsClient <- jmsClientRes
-      consumer  <- jmsClient.createAutoAcknowledgerConsumer(outputQueueName1, poolSize)
+      context   = jmsClient.context
+      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
+      message   <- Resource.liftF(context.createTextMessage(body))
       producer  <- jmsClient.createProducer(poolSize)
-    } yield (producer, consumer)
+    } yield (producer, consumer, message)
 
     res.use {
-      case (producer, consumer) =>
+      case (producer, consumer, message) =>
         for {
           producerTimestamp <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
-          _                 <- producer.sendWithDelay(messageWithDelayFactory((body, (outputQueueName1, Some(delay)))))
+          _                 <- producer.sendWithDelay(messageWithDelayFactory((message, (outputQueueName1, Some(delay)))))
           _                 <- logger.info(s"Pushed message with body: $body.")
           _                 <- logger.info(s"Consumer to Producer started. Collecting messages from output queue...")
-          text              <- receive(consumer, timeout)
+          receivedMessage   <- receiveMessage(consumer).timeout(timeout)
           deliveryTime      <- Timer[IO].clock.realTime(TimeUnit.MILLISECONDS)
+          actualBody        <- receivedMessage.asTextF[IO]
           actualDelay       = (deliveryTime - producerTimestamp).millis
-        } yield assert(actualDelay >= delayWithTolerance && text == body)
+        } yield assert(actualDelay >= delayWithTolerance && actualBody == body)
     }
   }
 }

--- a/tests/src/test/scala/jms4s/basespec/Jms4sBaseSpec.scala
+++ b/tests/src/test/scala/jms4s/basespec/Jms4sBaseSpec.scala
@@ -1,21 +1,23 @@
 package jms4s.basespec
 
 import cats.data.NonEmptyList
-import cats.effect.concurrent.Ref
-import cats.effect.{ Concurrent, ContextShift, IO, Resource }
+import cats.effect.concurrent.{ MVar, Ref }
+import cats.effect.{ Concurrent, ContextShift, IO, Resource, Timer }
 import cats.implicits._
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.config.{ DestinationName, QueueName, TopicName }
 import jms4s.jms.JmsMessage.JmsTextMessage
-import jms4s.jms.{ JmsContext, JmsMessageConsumer, MessageFactory }
+import jms4s.jms.{ JmsMessageConsumer, MessageFactory }
+import jms4s.{ JmsAutoAcknowledgerConsumer, JmsClient }
 
 import scala.concurrent.duration.{ FiniteDuration, _ }
 
 trait Jms4sBaseSpec {
   implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
-  def contextRes(implicit cs: ContextShift[IO]): Resource[IO, JmsContext[IO]]
+  def jmsClientRes(implicit cs: ContextShift[IO]): Resource[IO, JmsClient[IO]]
 
   val body                         = "body"
   val nMessages: Int               = 50
@@ -34,63 +36,49 @@ trait Jms4sBaseSpec {
     consumer.receiveJmsMessage
       .flatMap(_.asTextF[IO])
 
-  def receiveMessage(consumer: JmsMessageConsumer[IO]): IO[JmsTextMessage] =
-    consumer.receiveJmsMessage
-      .flatMap(_.asJmsTextMessageF[IO])
-
   def receiveUntil(
-    consumer: JmsMessageConsumer[IO],
+    consumer: JmsAutoAcknowledgerConsumer[IO],
     received: Ref[IO, Set[String]],
-    nMessages: Int
-  )(implicit F: Concurrent[IO]): IO[Set[String]] =
-    receiveBodyAsTextOrFail(consumer)
-      .flatMap(body => received.update(_ + body) *> received.get)
-      .iterateUntil(_.size == nMessages)
+    nMessages: Int,
+    duration: FiniteDuration
+  )(implicit F: Concurrent[IO], cs: ContextShift[IO], t: Timer[IO]): IO[Set[String]] = {
+    def readMessages =
+      consumer.handle((m, _) => m.asTextF[IO].flatMap(text => received.update(_ + text).as(AutoAckAction.noOp)))
 
-  def messageFactory(
-    message: JmsTextMessage,
-    destinationName: DestinationName
-  ): MessageFactory[IO] => IO[(JmsTextMessage, DestinationName)] = { mFactory: MessageFactory[IO] =>
-    message.asTextF[IO].flatMap { text =>
-      mFactory
-        .makeTextMessage(text)
-        .map(message => (message, destinationName))
-    }
+    for {
+      fiber <- readMessages.start
+      set   <- received.get.iterateUntil(_.size == nMessages).timeout(duration).guarantee(fiber.cancel)
+    } yield set
   }
 
-  def messageFactory(
-    message: JmsTextMessage
-  ): MessageFactory[IO] => IO[JmsTextMessage] = { mFactory: MessageFactory[IO] =>
-    message.asTextF[IO].flatMap(text => mFactory.makeTextMessage(text))
+  def receive(
+    consumer: JmsAutoAcknowledgerConsumer[IO],
+    duration: FiniteDuration
+  )(implicit F: Concurrent[IO], cs: ContextShift[IO], t: Timer[IO]): IO[String] = {
+    val received = MVar[IO].empty[String]
+
+    def readMessage(mVar: MVar[IO, String]) =
+      consumer.handle((m, _) => m.asTextF[IO].flatMap(tm => mVar.put(tm).as(AutoAckAction.noOp)))
+
+    for {
+      mVar  <- received
+      fiber <- readMessage(mVar).start
+      tm    <- mVar.read.timeout(duration).guarantee(fiber.cancel)
+    } yield tm
   }
 
   def messageWithDelayFactory(
-    message: (JmsTextMessage, (DestinationName, Option[FiniteDuration]))
+    message: (String, (DestinationName, Option[FiniteDuration]))
   ): MessageFactory[IO] => IO[(JmsTextMessage, (DestinationName, Option[FiniteDuration]))] = {
-    mFactory: MessageFactory[IO] =>
-      message._1.asTextF[IO].flatMap { text =>
-        mFactory
-          .makeTextMessage(text)
-          .map(m => (m, (message._2._1, message._2._2)))
-      }
+    mFactory: MessageFactory[IO] => mFactory.makeTextMessage(message._1).map(m => (m, message._2))
   }
 
   def messageFactory(
-    messages: NonEmptyList[JmsTextMessage]
-  ): MessageFactory[IO] => IO[NonEmptyList[JmsTextMessage]] = { mFactory: MessageFactory[IO] =>
-    messages
-      .map(message => message.asTextF[IO].flatMap(text => mFactory.makeTextMessage(text)))
-      .sequence
-  }
-
-  def messageFactory(
-    messages: NonEmptyList[JmsTextMessage],
+    texts: List[String],
     destinationName: DestinationName
   ): MessageFactory[IO] => IO[NonEmptyList[(JmsTextMessage, DestinationName)]] =
-    (mFactory: MessageFactory[IO]) =>
-      messages.map { message =>
-        IO.fromTry(message.getText)
-          .flatMap(text => mFactory.makeTextMessage(text))
-          .map(message => (message, destinationName))
-      }.sequence
+    mf =>
+      NonEmptyList
+        .fromListUnsafe(texts.map(b => mf.makeTextMessage(b).map(t => (t, destinationName))))
+        .sequence
 }

--- a/tests/src/test/scala/jms4s/basespec/Jms4sBaseSpec.scala
+++ b/tests/src/test/scala/jms4s/basespec/Jms4sBaseSpec.scala
@@ -22,7 +22,7 @@ trait Jms4sBaseSpec {
   val body                         = "body"
   val nMessages: Int               = 50
   val bodies: List[String]         = (0 until nMessages).map(i => s"$i").toList
-  val poolSize: Int                = 2
+  val poolSize: Int                = 1
   val timeout: FiniteDuration      = 4.seconds // CI is slow...
   val delay: FiniteDuration        = 200.millis
   val delayWithTolerance: Duration = delay * 0.8 // it looks like activemq is not fully respecting delivery delay

--- a/tests/src/test/scala/jms4s/basespec/providers/ActiveMQArtemisBaseSpec.scala
+++ b/tests/src/test/scala/jms4s/basespec/providers/ActiveMQArtemisBaseSpec.scala
@@ -2,27 +2,27 @@ package jms4s.basespec.providers
 
 import cats.data.NonEmptyList
 import cats.effect.{ Blocker, ContextShift, IO, Resource }
+import jms4s.JmsClient
 import jms4s.activemq.activeMQ
 import jms4s.activemq.activeMQ._
 import jms4s.basespec.Jms4sBaseSpec
-import jms4s.jms.JmsContext
 
 import scala.util.Random
 
 trait ActiveMQArtemisBaseSpec extends Jms4sBaseSpec {
 
-  override def contextRes(implicit cs: ContextShift[IO]): Resource[IO, JmsContext[IO]] =
+  override def jmsClientRes(implicit cs: ContextShift[IO]): Resource[IO, JmsClient[IO]] =
     for {
       blocker <- Blocker.apply[IO]
       rnd     <- Resource.liftF(IO(Random.nextInt))
-      ctx <- activeMQ.makeContext[IO](
-              Config(
-                endpoints = NonEmptyList.one(Endpoint("localhost", 61616)),
-                username = Some(Username("admin")),
-                password = Some(Password("passw0rd")),
-                clientId = ClientId("jms-specs" + rnd)
-              ),
-              blocker
-            )
-    } yield ctx
+      client <- activeMQ.makeJmsClient[IO](
+                 Config(
+                   endpoints = NonEmptyList.one(Endpoint("localhost", 61616)),
+                   username = Some(Username("admin")),
+                   password = Some(Password("passw0rd")),
+                   clientId = ClientId("jms-specs" + rnd)
+                 ),
+                 blocker
+               )
+    } yield client
 }

--- a/tests/src/test/scala/jms4s/basespec/providers/IbmMQBaseSpec.scala
+++ b/tests/src/test/scala/jms4s/basespec/providers/IbmMQBaseSpec.scala
@@ -2,18 +2,18 @@ package jms4s.basespec.providers
 
 import cats.data.NonEmptyList
 import cats.effect.{ Blocker, ContextShift, IO, Resource }
+import jms4s.JmsClient
 import jms4s.basespec.Jms4sBaseSpec
 import jms4s.ibmmq.ibmMQ
 import jms4s.ibmmq.ibmMQ._
-import jms4s.jms.JmsContext
 
 trait IbmMQBaseSpec extends Jms4sBaseSpec {
 
-  override def contextRes(implicit cs: ContextShift[IO]): Resource[IO, JmsContext[IO]] =
+  override def jmsClientRes(implicit cs: ContextShift[IO]): Resource[IO, JmsClient[IO]] =
     Blocker
       .apply[IO]
       .flatMap(blocker =>
-        ibmMQ.makeContext[IO](
+        ibmMQ.makeJmsClient[IO](
           Config(
             qm = QueueManager("QM1"),
             endpoints = NonEmptyList.one(Endpoint("localhost", 1414)),

--- a/tests/src/test/scala/jms4s/jms/JmsSpec.scala
+++ b/tests/src/test/scala/jms4s/jms/JmsSpec.scala
@@ -4,11 +4,11 @@ import java.util.concurrent.TimeUnit
 
 import cats.effect.testing.scalatest.AsyncIOSpec
 import cats.effect.{ IO, Resource, Timer }
+import cats.implicits._
 import jms4s.basespec.Jms4sBaseSpec
+import jms4s.config.DestinationName
 import jms4s.model.SessionType
 import org.scalatest.freespec.AsyncFreeSpec
-import cats.implicits._
-import jms4s.config.DestinationName
 
 import scala.concurrent.duration._
 
@@ -16,7 +16,8 @@ trait JmsSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
   private def contexts(destination: DestinationName) =
     for {
-      context         <- contextRes
+      client          <- jmsClientRes
+      context         = client.context
       receiveConsumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(destination))
       sendContext     <- context.createContext(SessionType.AutoAcknowledge)
       msg             <- Resource.liftF(context.createTextMessage(body))


### PR DESCRIPTION
In this PR I refactor the code in order to avoid JmsContext to be returned to the user.

The specific provider will be responsible to create a JmsClient and then the user will be able to create programs from it.