### PR TITLE
Introduce pollingInterval to JMS consumers

### DIFF
--- a/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
@@ -42,7 +42,8 @@ object JmsAcknowledgerConsumer {
   private[jms4s] def make[F[_]: Async](
     context: JmsContext[F],
     inputDestinationName: DestinationName,
-    concurrencyLevel: Int
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration
   ): Resource[F, JmsAcknowledgerConsumer[F]] =
     for {
       pool <- Resource.eval(
@@ -51,7 +52,7 @@ object JmsAcknowledgerConsumer {
       _ <- (0 until concurrencyLevel).toList.traverse_ { _ =>
             for {
               ctx      <- context.createContext(SessionType.ClientAcknowledge)
-              consumer <- ctx.createJmsConsumer(inputDestinationName)
+              consumer <- ctx.createJmsConsumer(inputDestinationName, pollingInterval)
               _        <- Resource.eval(pool.offer((ctx, consumer, MessageFactory[F](ctx))))
             } yield ()
           }

--- a/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
@@ -43,7 +43,8 @@ object JmsAutoAcknowledgerConsumer {
   private[jms4s] def make[F[_]: Async](
     context: JmsContext[F],
     inputDestinationName: DestinationName,
-    concurrencyLevel: Int
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
     for {
       pool <- Resource.eval(
@@ -52,7 +53,7 @@ object JmsAutoAcknowledgerConsumer {
       _ <- (0 until concurrencyLevel).toList.traverse_ { _ =>
             for {
               ctx      <- context.createContext(SessionType.AutoAcknowledge)
-              consumer <- ctx.createJmsConsumer(inputDestinationName)
+              consumer <- ctx.createJmsConsumer(inputDestinationName, pollingInterval)
               _        <- Resource.eval(pool.offer((ctx, consumer, MessageFactory[F](ctx))))
             } yield ()
           }

--- a/core/src/main/scala/jms4s/JmsClient.scala
+++ b/core/src/main/scala/jms4s/JmsClient.scala
@@ -25,25 +25,30 @@ import cats.effect.{ Async, Resource }
 import jms4s.config.DestinationName
 import jms4s.jms._
 
+import scala.concurrent.duration.FiniteDuration
+
 class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsContext[F]) {
 
   def createTransactedConsumer(
     inputDestinationName: DestinationName,
-    concurrencyLevel: Int
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration
   ): Resource[F, JmsTransactedConsumer[F]] =
-    JmsTransactedConsumer.make(context, inputDestinationName, concurrencyLevel)
+    JmsTransactedConsumer.make(context, inputDestinationName, concurrencyLevel, pollingInterval)
 
   def createAutoAcknowledgerConsumer(
     inputDestinationName: DestinationName,
-    concurrencyLevel: Int
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
-    JmsAutoAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel)
+    JmsAutoAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel, pollingInterval)
 
   def createAcknowledgerConsumer(
     inputDestinationName: DestinationName,
-    concurrencyLevel: Int
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration
   ): Resource[F, JmsAcknowledgerConsumer[F]] =
-    JmsAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel)
+    JmsAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel, pollingInterval)
 
   def createProducer(
     concurrencyLevel: Int

--- a/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
@@ -43,7 +43,8 @@ object JmsTransactedConsumer {
   private[jms4s] def make[F[_]: Async](
     context: JmsContext[F],
     inputDestinationName: DestinationName,
-    concurrencyLevel: Int
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration
   ): Resource[F, JmsTransactedConsumer[F]] =
     for {
       pool <- Resource.eval(
@@ -53,7 +54,7 @@ object JmsTransactedConsumer {
             .traverse_(_ =>
               for {
                 c        <- context.createContext(SessionType.Transacted)
-                consumer <- c.createJmsConsumer(inputDestinationName)
+                consumer <- c.createJmsConsumer(inputDestinationName, pollingInterval)
                 _        <- Resource.eval(pool.offer((c, consumer, MessageFactory[F](c))))
               } yield ()
             )

--- a/core/src/main/scala/jms4s/jms/JmsContext.scala
+++ b/core/src/main/scala/jms4s/jms/JmsContext.scala
@@ -65,7 +65,10 @@ class JmsContext[F[_]: Async: Logger](
           )
     } yield ()
 
-  def createJmsConsumer(destinationName: DestinationName): Resource[F, JmsMessageConsumer[F]] =
+  def createJmsConsumer(
+    destinationName: DestinationName,
+    pollingInterval: FiniteDuration
+  ): Resource[F, JmsMessageConsumer[F]] =
     for {
       destination <- Resource.eval(createDestination(destinationName))
       consumer <- Resource.make(
@@ -75,7 +78,7 @@ class JmsContext[F[_]: Async: Logger](
                    Logger[F].info(s"Closing consumer for destination $destinationName") *>
                      Sync[F].blocking(consumer.close())
                  )
-    } yield new JmsMessageConsumer[F](consumer)
+    } yield new JmsMessageConsumer[F](consumer, pollingInterval)
 
   def createTextMessage(value: String): F[JmsTextMessage] =
     Sync[F].delay(new JmsTextMessage(context.createTextMessage(value)))

--- a/examples/src/main/scala/AckConsumerExample.scala
+++ b/examples/src/main/scala/AckConsumerExample.scala
@@ -25,6 +25,8 @@ import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
 import jms4s.jms.MessageFactory
 
+import scala.concurrent.duration._
+
 class AckConsumerExample extends IOApp {
 
   val contextRes: Resource[IO, JmsClient[IO]] = null // see providers section!
@@ -42,7 +44,7 @@ class AckConsumerExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
       client   <- contextRes
-      consumer <- client.createAcknowledgerConsumer(inputQueue, 10)
+      consumer <- client.createAcknowledgerConsumer(inputQueue, 10, 100.millis)
     } yield consumer
 
     consumerRes.use(_.handle { (jmsMessage, mf) =>

--- a/examples/src/main/scala/AutoAckConsumerExample.scala
+++ b/examples/src/main/scala/AutoAckConsumerExample.scala
@@ -25,6 +25,8 @@ import jms4s.JmsClient
 import jms4s.config.{ QueueName, TopicName }
 import jms4s.jms.MessageFactory
 
+import scala.concurrent.duration._
+
 class AutoAckConsumerExample extends IOApp {
 
   val jmsClient: Resource[IO, JmsClient[IO]] = null // see providers section!
@@ -41,7 +43,7 @@ class AutoAckConsumerExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
       client   <- jmsClient
-      consumer <- client.createAutoAcknowledgerConsumer(inputQueue, 10)
+      consumer <- client.createAutoAcknowledgerConsumer(inputQueue, 10, 100.millis)
     } yield consumer
 
     consumerRes.use(_.handle { (jmsMessage, mf) =>

--- a/examples/src/main/scala/TransactedConsumerExample.scala
+++ b/examples/src/main/scala/TransactedConsumerExample.scala
@@ -25,6 +25,8 @@ import jms4s.JmsTransactedConsumer._
 import jms4s.config.{ QueueName, TopicName }
 import jms4s.jms.MessageFactory
 
+import scala.concurrent.duration._
+
 class TransactedConsumerExample extends IOApp {
 
   val jmsClient: Resource[IO, JmsClient[IO]] = null // see providers section!
@@ -41,7 +43,7 @@ class TransactedConsumerExample extends IOApp {
   override def run(args: List[String]): IO[ExitCode] = {
     val consumerRes = for {
       client   <- jmsClient
-      consumer <- client.createTransactedConsumer(inputQueue, 10)
+      consumer <- client.createTransactedConsumer(inputQueue, 10, 100.millis)
     } yield consumer
 
     consumerRes.use(_.handle { (jmsMessage, mf) =>

--- a/tests/src/test/scala/jms4s/JmsClientSpec.scala
+++ b/tests/src/test/scala/jms4s/JmsClientSpec.scala
@@ -38,7 +38,7 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient   <- jmsClientRes
       context     = jmsClient.context
-      consumer    <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
+      consumer    <- jmsClient.createTransactedConsumer(inputQueueName, poolSize, pollingInterval)
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       messages    <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
     } yield (consumer, sendContext, bodies.toSet, messages)
@@ -67,11 +67,15 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient   <- jmsClientRes
       context     = jmsClient.context
-      consumer    <- jmsClient.createTransactedConsumer(inputQueueName, poolSize)
+      consumer    <- jmsClient.createTransactedConsumer(inputQueueName, poolSize, pollingInterval)
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       messages    <- Resource.eval(bodies.traverse(i => sendContext.createTextMessage(i)))
-      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+      consumer1 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      consumer2 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName2, pollingInterval))
     } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
@@ -106,7 +110,7 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient   <- jmsClientRes
       context     = jmsClient.context
-      consumer    <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
+      consumer    <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize, pollingInterval)
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       messages    <- Resource.eval(bodies.traverse(i => sendContext.createTextMessage(i)))
     } yield (consumer, sendContext, bodies.toSet, messages)
@@ -135,11 +139,15 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient   <- jmsClientRes
       context     = jmsClient.context
-      consumer    <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize)
+      consumer    <- jmsClient.createAcknowledgerConsumer(inputQueueName, poolSize, pollingInterval)
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       messages    <- Resource.eval(bodies.traverse(i => sendContext.createTextMessage(i)))
-      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+      consumer1 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      consumer2 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName2, pollingInterval))
     } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
@@ -174,7 +182,7 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient   <- jmsClientRes
       context     = jmsClient.context
-      consumer    <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
+      consumer    <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize, pollingInterval)
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       messages    <- Resource.eval(bodies.traverse(i => sendContext.createTextMessage(i)))
     } yield (consumer, sendContext, bodies.toSet, messages)
@@ -203,11 +211,15 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient   <- jmsClientRes
       context     = jmsClient.context
-      consumer    <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize)
+      consumer    <- jmsClient.createAutoAcknowledgerConsumer(inputQueueName, poolSize, pollingInterval)
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       messages    <- Resource.eval(bodies.traverse(i => sendContext.createTextMessage(i)))
-      consumer1   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2   <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+      consumer1 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      consumer2 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName2, pollingInterval))
 
     } yield (consumer, sendContext, consumer1, consumer2, bodies.toSet, messages)
 
@@ -242,9 +254,11 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient <- jmsClientRes
       context   = jmsClient.context
-      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      messages  <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
-      producer  <- jmsClient.createProducer(poolSize)
+      consumer <- context
+                   .createContext(SessionType.AutoAcknowledge)
+                   .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      messages <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
+      producer <- jmsClient.createProducer(poolSize)
     } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
@@ -264,9 +278,11 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient <- jmsClientRes
       context   = jmsClient.context
-      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      messages  <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
-      producer  <- jmsClient.createProducer(poolSize)
+      consumer <- context
+                   .createContext(SessionType.AutoAcknowledge)
+                   .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      messages <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
+      producer <- jmsClient.createProducer(poolSize)
     } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
@@ -286,9 +302,11 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient <- jmsClientRes
       context   = jmsClient.context
-      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
-      messages  <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
-      producer  <- jmsClient.createProducer(poolSize)
+      consumer <- context
+                   .createContext(SessionType.AutoAcknowledge)
+                   .flatMap(_.createJmsConsumer(topicName1, pollingInterval))
+      messages <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
+      producer <- jmsClient.createProducer(poolSize)
     } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
@@ -308,9 +326,11 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient <- jmsClientRes
       context   = jmsClient.context
-      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
-      messages  <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
-      producer  <- jmsClient.createProducer(poolSize)
+      consumer <- context
+                   .createContext(SessionType.AutoAcknowledge)
+                   .flatMap(_.createJmsConsumer(topicName1, pollingInterval))
+      messages <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
+      producer <- jmsClient.createProducer(poolSize)
     } yield (producer, consumer, bodies.toSet, messages)
 
     res.use {
@@ -332,8 +352,12 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
       context   = jmsClient.context
       messages  <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-      consumer1 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      consumer2 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName2))
+      consumer1 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      consumer2 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(outputQueueName2, pollingInterval))
     } yield (producer, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
@@ -363,8 +387,12 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
       context   = jmsClient.context
       messages  <- Resource.eval(bodies.traverse(i => context.createTextMessage(i)))
       producer  <- jmsClient.createProducer(poolSize)
-      consumer1 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName1))
-      consumer2 <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(topicName2))
+      consumer1 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(topicName1, pollingInterval))
+      consumer2 <- context
+                    .createContext(SessionType.AutoAcknowledge)
+                    .flatMap(_.createJmsConsumer(topicName2, pollingInterval))
     } yield (producer, consumer1, consumer2, bodies.toSet, messages)
 
     res.use {
@@ -387,9 +415,11 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     val res = for {
       jmsClient <- jmsClientRes
       context   = jmsClient.context
-      consumer  <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(outputQueueName1))
-      message   <- Resource.eval(context.createTextMessage(body))
-      producer  <- jmsClient.createProducer(poolSize)
+      consumer <- context
+                   .createContext(SessionType.AutoAcknowledge)
+                   .flatMap(_.createJmsConsumer(outputQueueName1, pollingInterval))
+      message  <- Resource.eval(context.createTextMessage(body))
+      producer <- jmsClient.createProducer(poolSize)
     } yield (producer, consumer, message)
 
     res.use {

--- a/tests/src/test/scala/jms4s/basespec/Jms4sBaseSpec.scala
+++ b/tests/src/test/scala/jms4s/basespec/Jms4sBaseSpec.scala
@@ -43,6 +43,7 @@ trait Jms4sBaseSpec {
   val bodies: List[String]         = (0 until nMessages).map(i => s"$i").toList
   val poolSize: Int                = 2
   val timeout: FiniteDuration      = 4.seconds // CI is slow...
+  val pollingInterval              = 100.millis
   val delay: FiniteDuration        = 200.millis
   val delayWithTolerance: Duration = delay * 0.8 // it looks like activemq is not fully respecting delivery delay
   val topicName1: TopicName        = TopicName("DEV.BASE.TOPIC")

--- a/tests/src/test/scala/jms4s/jms/JmsSpec.scala
+++ b/tests/src/test/scala/jms4s/jms/JmsSpec.scala
@@ -34,11 +34,13 @@ trait JmsSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
 
   private def contexts(destination: DestinationName) =
     for {
-      client          <- jmsClientRes
-      context         = client.context
-      receiveConsumer <- context.createContext(SessionType.AutoAcknowledge).flatMap(_.createJmsConsumer(destination))
-      sendContext     <- context.createContext(SessionType.AutoAcknowledge)
-      msg             <- Resource.eval(context.createTextMessage(body))
+      client  <- jmsClientRes
+      context = client.context
+      receiveConsumer <- context
+                          .createContext(SessionType.AutoAcknowledge)
+                          .flatMap(_.createJmsConsumer(destination, pollingInterval))
+      sendContext <- context.createContext(SessionType.AutoAcknowledge)
+      msg         <- Resource.eval(context.createTextMessage(body))
     } yield (receiveConsumer, sendContext, msg)
 
   "publish to a queue and then receive" in {


### PR DESCRIPTION
This PR solves problem of high idle CPU consumption by adding pollingInterval to consumer loop. If this PR is fine, I will also open a backport PR into 0.0.x series, since I highly interested in CE2-compatible artifact