### PR TITLE
Replace `val`s with `def`s for JmsMessage properties

### DIFF
--- a/core/src/main/scala/jms4s/jms/JmsMessage.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessage.scala
@@ -23,10 +23,10 @@ package jms4s.jms
 
 import cats.syntax.all._
 import cats.{ ApplicativeError, Show }
-import javax.jms.{ Destination, Message, TextMessage }
 import jms4s.jms.JmsMessage.{ JmsTextMessage, UnsupportedMessage }
 import jms4s.jms.utils.TryUtils._
 
+import javax.jms.{ Destination, Message, TextMessage }
 import scala.util.control.NoStackTrace
 import scala.util.{ Failure, Success, Try }
 
@@ -45,26 +45,32 @@ class JmsMessage private[jms4s] (private[jms4s] val wrapped: Message) {
   def asTextF[F[_]](implicit a: ApplicativeError[F, Throwable]): F[String] =
     ApplicativeError[F, Throwable].fromTry(attemptAsText)
 
-  def setJMSCorrelationId(correlationId: String): Try[Unit] = Try(wrapped.setJMSCorrelationID(correlationId))
-  def setJMSReplyTo(destination: JmsDestination): Try[Unit] = Try(wrapped.setJMSReplyTo(destination.wrapped))
-  def setJMSType(`type`: String): Try[Unit]                 = Try(wrapped.setJMSType(`type`))
+  def setJMSCorrelationId(correlationId: String): Try[Unit]     = Try(wrapped.setJMSCorrelationID(correlationId))
+  def setJMSReplyTo(destination: JmsDestination): Try[Unit]     = Try(wrapped.setJMSReplyTo(destination.wrapped))
+  def setJMSType(`type`: String): Try[Unit]                     = Try(wrapped.setJMSType(`type`))
+  def setJMSMessageID(messageID: String): Try[Unit]             = Try(wrapped.setJMSMessageID(messageID))
+  def setJMSTimestamp(timestamp: Long): Try[Unit]               = Try(wrapped.setJMSTimestamp(timestamp))
+  def setJMSDestination(destination: JmsDestination): Try[Unit] = Try(wrapped.setJMSDestination(destination.wrapped))
+  def setJMSDeliveryMode(deliveryMode: Int): Try[Unit]          = Try(wrapped.setJMSDeliveryMode(deliveryMode))
+  def setJMSRedelivered(redelivered: Boolean): Try[Unit]        = Try(wrapped.setJMSRedelivered(redelivered))
+  def setJMSExpiration(expiration: Long): Try[Unit]             = Try(wrapped.setJMSExpiration(expiration))
+  def setJMSPriority(priority: Int): Try[Unit]                  = Try(wrapped.setJMSPriority(priority))
 
   def setJMSCorrelationIDAsBytes(correlationId: Array[Byte]): Try[Unit] =
     Try(wrapped.setJMSCorrelationIDAsBytes(correlationId))
 
-  val getJMSMessageId: Option[String]     = Try(Option(wrapped.getJMSMessageID)).toOpt
-  val getJMSTimestamp: Option[Long]       = Try(Option(wrapped.getJMSTimestamp)).toOpt
-  val getJMSCorrelationId: Option[String] = Try(Option(wrapped.getJMSCorrelationID)).toOpt
-
-  val getJMSCorrelationIdAsBytes: Option[Array[Byte]] = Try(Option(wrapped.getJMSCorrelationIDAsBytes)).toOpt
-  val getJMSReplyTo: Option[Destination]              = Try(Option(wrapped.getJMSReplyTo)).toOpt
-  val getJMSDestination: Option[Destination]          = Try(Option(wrapped.getJMSDestination)).toOpt
-  val getJMSDeliveryMode: Option[Int]                 = Try(Option(wrapped.getJMSDeliveryMode)).toOpt
-  val getJMSRedelivered: Option[Boolean]              = Try(Option(wrapped.getJMSRedelivered)).toOpt
-  val getJMSType: Option[String]                      = Try(Option(wrapped.getJMSType)).toOpt
-  val getJMSExpiration: Option[Long]                  = Try(Option(wrapped.getJMSExpiration)).toOpt
-  val getJMSPriority: Option[Int]                     = Try(Option(wrapped.getJMSPriority)).toOpt
-  val getJMSDeliveryTime: Option[Long]                = Try(Option(wrapped.getJMSDeliveryTime)).toOpt
+  def getJMSMessageId: Option[String]                 = Try(Option(wrapped.getJMSMessageID)).toOpt
+  def getJMSTimestamp: Option[Long]                   = Try(Option(wrapped.getJMSTimestamp)).toOpt
+  def getJMSCorrelationId: Option[String]             = Try(Option(wrapped.getJMSCorrelationID)).toOpt
+  def getJMSCorrelationIdAsBytes: Option[Array[Byte]] = Try(Option(wrapped.getJMSCorrelationIDAsBytes)).toOpt
+  def getJMSReplyTo: Option[Destination]              = Try(Option(wrapped.getJMSReplyTo)).toOpt
+  def getJMSDestination: Option[Destination]          = Try(Option(wrapped.getJMSDestination)).toOpt
+  def getJMSDeliveryMode: Option[Int]                 = Try(Option(wrapped.getJMSDeliveryMode)).toOpt
+  def getJMSRedelivered: Option[Boolean]              = Try(Option(wrapped.getJMSRedelivered)).toOpt
+  def getJMSType: Option[String]                      = Try(Option(wrapped.getJMSType)).toOpt
+  def getJMSExpiration: Option[Long]                  = Try(Option(wrapped.getJMSExpiration)).toOpt
+  def getJMSPriority: Option[Int]                     = Try(Option(wrapped.getJMSPriority)).toOpt
+  def getJMSDeliveryTime: Option[Long]                = Try(Option(wrapped.getJMSDeliveryTime)).toOpt
 
   def getBooleanProperty(name: String): Option[Boolean] =
     Try(Option(wrapped.getBooleanProperty(name))).toOpt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,42 @@
-ibmmq:
-  image: ibmcom/mq:9.2.3.0-r1 # https://github.com/ibm-messaging/mq-container
-  ports:
-    - "1414:1414"
-    - "9443:9443" #  https://localhost:9443/ibmmq/console/
-  volumes:
-    - ./scripts/definitions.mqsc:/etc/mqm/definitions.mqsc:ro
-  environment:
-    - LICENSE=accept
-    - MQ_QMGR_NAME=QM1
-# Users
-# Userid: admin Groups: mqm Password: passw0rd
-# Userid: app Groups: mqclient Password:
+services:
+  
+  ibmmq:
+    image: ibmcom/mq:9.2.3.0-r1 # https://github.com/ibm-messaging/mq-container
+    ports:
+      - "1414:1414"
+      - "9443:9443" #  https://localhost:9443/ibmmq/console/
+    volumes:
+      - ./scripts/definitions.mqsc:/etc/mqm/definitions.mqsc:ro
+    environment:
+      - LICENSE=accept
+      - MQ_QMGR_NAME=QM1
+  # Users
+  # Userid: admin Groups: mqm Password: passw0rd
+  # Userid: app Groups: mqclient Password:
 
-#  Queues
-#  DEV.QUEUE.1
-#  DEV.QUEUE.2
-#  DEV.QUEUE.3
-#  DEV.DEAD.LETTER.QUEUE - Set as the Queue Manager's Dead Letter Queue.
+  #  Queues
+  #  DEV.QUEUE.1
+  #  DEV.QUEUE.2
+  #  DEV.QUEUE.3
+  #  DEV.DEAD.LETTER.QUEUE - Set as the Queue Manager's Dead Letter Queue.
 
-#  Channels
-#  DEV.ADMIN.SVRCONN - Set to only allow the admin user to connect into it and a Userid + Password must be supplied.
-#  DEV.APP.SVRCONN - Does not allow Administrator users to connect.
+  #  Channels
+  #  DEV.ADMIN.SVRCONN - Set to only allow the admin user to connect into it and a Userid + Password must be supplied.
+  #  DEV.APP.SVRCONN - Does not allow Administrator users to connect.
 
-#  Listener
-#  DEV.LISTENER.TCP - Listening on Port 1414.
+  #  Listener
+  #  DEV.LISTENER.TCP - Listening on Port 1414.
 
-#  Topic
-#  DEV.BASE.TOPIC - With a topic string of dev/
+  #  Topic
+  #  DEV.BASE.TOPIC - With a topic string of dev/
 
-activemq:
-  image: vromero/activemq-artemis:2.16.0 # https://github.com/vromero/activemq-artemis-docker/blob/master/README.md
-  ports:
-    - "8161:8161" # http://localhost:8161/console
-    - "61616:61616"
-  volumes:
-    - ./scripts/broker-00.xml:/var/lib/artemis/etc-override/broker-00.xml:ro
-  environment:
-    - ARTEMIS_USERNAME=admin
-    - ARTEMIS_PASSWORD=passw0rd
+  activemq:
+    image: vromero/activemq-artemis:2.16.0 # https://github.com/vromero/activemq-artemis-docker/blob/master/README.md
+    ports:
+      - "8161:8161" # http://localhost:8161/console
+      - "61616:61616"
+    volumes:
+      - ./scripts/broker-00.xml:/var/lib/artemis/etc-override/broker-00.xml:ro
+    environment:
+      - ARTEMIS_USERNAME=admin
+      - ARTEMIS_PASSWORD=passw0rd

--- a/tests/src/test/scala/jms4s/jms/JmsSpec.scala
+++ b/tests/src/test/scala/jms4s/jms/JmsSpec.scala
@@ -74,4 +74,14 @@ trait JmsSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
         } yield assert(rec == body)
     }
   }
+
+  "update and get a JMSMessage property" in {
+    contexts(topicName1).use {
+      case (_, _, msg) =>
+        for {
+          _ <- IO.fromTry(msg.setJMSType("newType"))
+          t = msg.getJMSType
+        } yield assert(t.contains("newType"))
+    }
+  }
 }


### PR DESCRIPTION
This PR fix the behaviour where the old value is returned when updating a value of the JmsMessage.
These getters once were `IO` (instead of `Try`) and so the expression was evaluated every time and the usage of `val` was ok; when migrated to Try the value is evaluated once at construction-time of the class and never re-evaluated.