### PR TITLE
Blocking ops & MessageFactory in pool

### DIFF
--- a/core/src/main/scala/jms4s/jms/JmsMessage.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessage.scala
@@ -155,6 +155,6 @@ object JmsMessage {
     def setText(text: String): Try[Unit] =
       Try(wrapped.setText(text))
 
-    val getText: Try[String] = Try(wrapped.getText)
+    def getText: Try[String] = Try(wrapped.getText)
   }
 }

--- a/core/src/main/scala/jms4s/jms/JmsMessage.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessage.scala
@@ -108,7 +108,6 @@ class JmsMessage private[jms4s] (private[jms4s] val wrapped: Message) {
 }
 
 object JmsMessage {
-  import scala.jdk.CollectionConverters._
 
   implicit val showMessage: Show[Message] = Show.show[Message] { message =>
     def getStringContent: Try[String] = message match {
@@ -116,8 +115,15 @@ object JmsMessage {
       case _                    => Failure(new RuntimeException())
     }
 
-    def propertyNames: List[String] =
-      message.getPropertyNames.asScala.toList.map(_.toString)
+    def propertyNames: List[String] = {
+      val e   = message.getPropertyNames
+      val buf = collection.mutable.Buffer.empty[String]
+      while (e.hasMoreElements) {
+        val propertyName = e.nextElement.asInstanceOf[String]
+        buf += propertyName
+      }
+      buf.toList
+    }
 
     Try {
       s"""

--- a/core/src/main/scala/jms4s/jms/JmsMessage.scala
+++ b/core/src/main/scala/jms4s/jms/JmsMessage.scala
@@ -108,6 +108,7 @@ class JmsMessage private[jms4s] (private[jms4s] val wrapped: Message) {
 }
 
 object JmsMessage {
+  import scala.jdk.CollectionConverters._
 
   implicit val showMessage: Show[Message] = Show.show[Message] { message =>
     def getStringContent: Try[String] = message match {
@@ -115,15 +116,8 @@ object JmsMessage {
       case _                    => Failure(new RuntimeException())
     }
 
-    def propertyNames: List[String] = {
-      val e   = message.getPropertyNames
-      val buf = collection.mutable.Buffer.empty[String]
-      while (e.hasMoreElements) {
-        val propertyName = e.nextElement.asInstanceOf[String]
-        buf += propertyName
-      }
-      buf.toList
-    }
+    def propertyNames: List[String] =
+      message.getPropertyNames.asScala.toList.map(_.toString)
 
     Try {
       s"""

--- a/core/src/main/scala/jms4s/jms/MessageFactory.scala
+++ b/core/src/main/scala/jms4s/jms/MessageFactory.scala
@@ -23,7 +23,7 @@ package jms4s.jms
 
 import jms4s.jms.JmsMessage.JmsTextMessage
 
-class MessageFactory[F[_]](context: JmsContext[F]) {
+class MessageFactory[F[_]](private val context: JmsContext[F]) extends AnyVal {
   def makeTextMessage(value: String): F[JmsTextMessage] = context.createTextMessage(value)
 }
 

--- a/core/src/main/scala/jms4s/jms/utils/TryUtils.scala
+++ b/core/src/main/scala/jms4s/jms/utils/TryUtils.scala
@@ -25,7 +25,7 @@ import scala.util.{ Success, Try }
 
 object TryUtils {
 
-  implicit class TryUtils[T](val underlying: Try[Option[T]]) {
+  implicit class TryUtils[T](val underlying: Try[Option[T]]) extends AnyVal {
 
     def toOpt: Option[T] =
       underlying match {


### PR DESCRIPTION
This PR "marks" other `JMSContext` operations (createTextMessage, createQueue ecc) as blocking: in the implementations (ibm/activemq) various syncronization and blocking machinery are used in these methods.
Additionally, in the `JmsProducer` side, now for each context in the pool, there is a related `MessageFactory` built with that context. (similar to what is already happening on the consuming side)
Before this change, each function `MessageFactory[F] => F[....]` was using the only one `MessageFactory` available.
Some other minor fixies has been done