### PR TITLE
Refactoring context pool

### DIFF
--- a/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAcknowledgerConsumer.scala
@@ -36,7 +36,7 @@ trait JmsAcknowledgerConsumer[F[_]] {
 
 object JmsAcknowledgerConsumer {
 
-  private[jms4s] def make[F[_]: Async](rawConsumer: MessageConsumer[F]): JmsAcknowledgerConsumer[F] =
+  private[jms4s] def make[F[_]: Async](rawConsumer: PooledConsumer[F]): JmsAcknowledgerConsumer[F] =
     (action: (JmsMessage, MessageFactory[F]) => F[AckAction[F]]) =>
       {
         rawConsumer.consume {

--- a/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsAutoAcknowledgerConsumer.scala
@@ -37,7 +37,7 @@ trait JmsAutoAcknowledgerConsumer[F[_]] {
 
 object JmsAutoAcknowledgerConsumer {
 
-  private[jms4s] def make[F[_]: Async](rawConsumer: MessageConsumer[F]): JmsAutoAcknowledgerConsumer[F] =
+  private[jms4s] def make[F[_]: Async](rawConsumer: PooledConsumer[F]): JmsAutoAcknowledgerConsumer[F] =
     (action: (JmsMessage, MessageFactory[F]) => F[AutoAckAction[F]]) =>
       rawConsumer.consume {
         case (message, context, mf) =>

--- a/core/src/main/scala/jms4s/JmsClient.scala
+++ b/core/src/main/scala/jms4s/JmsClient.scala
@@ -35,8 +35,8 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration
   ): Resource[F, JmsTransactedConsumer[F]] =
-    MessageConsumer
-      .pooled[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.Transacted)
+    PooledConsumer
+      .make[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.Transacted)
       .map(JmsTransactedConsumer.make(_))
 
   def createAutoAcknowledgerConsumer(
@@ -44,8 +44,8 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
-    MessageConsumer
-      .pooled[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.AutoAcknowledge)
+    PooledConsumer
+      .make[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.AutoAcknowledge)
       .map(JmsAutoAcknowledgerConsumer.make(_))
 
   def createAcknowledgerConsumer(
@@ -53,8 +53,8 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration
   ): Resource[F, JmsAcknowledgerConsumer[F]] =
-    MessageConsumer
-      .pooled[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.ClientAcknowledge)
+    PooledConsumer
+      .make[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.ClientAcknowledge)
       .map(JmsAcknowledgerConsumer.make(_))
 
   def createProducer(

--- a/core/src/main/scala/jms4s/JmsClient.scala
+++ b/core/src/main/scala/jms4s/JmsClient.scala
@@ -24,6 +24,7 @@ package jms4s
 import cats.effect.{ Async, Resource }
 import jms4s.config.DestinationName
 import jms4s.jms._
+import jms4s.model.SessionType
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -34,21 +35,27 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration
   ): Resource[F, JmsTransactedConsumer[F]] =
-    JmsTransactedConsumer.make(context, inputDestinationName, concurrencyLevel, pollingInterval)
+    MessageConsumer
+      .pooled(context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.Transacted)
+      .map(JmsTransactedConsumer.make(_))
 
   def createAutoAcknowledgerConsumer(
     inputDestinationName: DestinationName,
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
-    JmsAutoAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel, pollingInterval)
+    MessageConsumer
+      .pooled(context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.AutoAcknowledge)
+      .map(JmsAutoAcknowledgerConsumer.make(_))
 
   def createAcknowledgerConsumer(
     inputDestinationName: DestinationName,
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration
   ): Resource[F, JmsAcknowledgerConsumer[F]] =
-    JmsAcknowledgerConsumer.make(context, inputDestinationName, concurrencyLevel, pollingInterval)
+    MessageConsumer
+      .pooled(context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.ClientAcknowledge)
+      .map(JmsAcknowledgerConsumer.make(_))
 
   def createProducer(
     concurrencyLevel: Int

--- a/core/src/main/scala/jms4s/JmsClient.scala
+++ b/core/src/main/scala/jms4s/JmsClient.scala
@@ -36,7 +36,7 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     pollingInterval: FiniteDuration
   ): Resource[F, JmsTransactedConsumer[F]] =
     MessageConsumer
-      .pooled(context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.Transacted)
+      .pooled[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.Transacted)
       .map(JmsTransactedConsumer.make(_))
 
   def createAutoAcknowledgerConsumer(
@@ -45,7 +45,7 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     pollingInterval: FiniteDuration
   ): Resource[F, JmsAutoAcknowledgerConsumer[F]] =
     MessageConsumer
-      .pooled(context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.AutoAcknowledge)
+      .pooled[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.AutoAcknowledge)
       .map(JmsAutoAcknowledgerConsumer.make(_))
 
   def createAcknowledgerConsumer(
@@ -54,12 +54,12 @@ class JmsClient[F[_]: Async] private[jms4s] (private[jms4s] val context: JmsCont
     pollingInterval: FiniteDuration
   ): Resource[F, JmsAcknowledgerConsumer[F]] =
     MessageConsumer
-      .pooled(context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.ClientAcknowledge)
+      .pooled[F](context, inputDestinationName, concurrencyLevel, pollingInterval, SessionType.ClientAcknowledge)
       .map(JmsAcknowledgerConsumer.make(_))
 
   def createProducer(
     concurrencyLevel: Int
   ): Resource[F, JmsProducer[F]] =
-    JmsProducer.make(context, concurrencyLevel)
+    JmsProducer.make[F](context, concurrencyLevel)
 
 }

--- a/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
+++ b/core/src/main/scala/jms4s/JmsTransactedConsumer.scala
@@ -36,7 +36,7 @@ trait JmsTransactedConsumer[F[_]] {
 
 object JmsTransactedConsumer {
 
-  private[jms4s] def make[F[_]: Async](rawConsumer: MessageConsumer[F]): JmsTransactedConsumer[F] =
+  private[jms4s] def make[F[_]: Async](rawConsumer: PooledConsumer[F]): JmsTransactedConsumer[F] =
     (f: (JmsMessage, MessageFactory[F]) => F[TransactionAction[F]]) =>
       rawConsumer.consume {
         case (received, context, mf) =>

--- a/core/src/main/scala/jms4s/jms/MessageConsumer.scala
+++ b/core/src/main/scala/jms4s/jms/MessageConsumer.scala
@@ -1,0 +1,58 @@
+package jms4s.jms
+
+import cats.effect.Resource
+import cats.effect.kernel.{ Async, Concurrent }
+import cats.effect.std.Queue
+import cats.syntax.all._
+import fs2._
+import jms4s.config.DestinationName
+import jms4s.model.SessionType
+
+import scala.concurrent.duration.FiniteDuration
+
+private[jms4s] class MessageConsumer[F[_]: Concurrent, A](
+  pool: Queue[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])],
+  concurrencyLevel: Int
+) {
+
+  def consume(f: (JmsMessage, JmsContext[F], MessageFactory[F]) => F[A]): F[Unit] =
+    Stream
+      .emit(Stream.resource(take).evalMap {
+        case (context, consumer, mf) =>
+          for {
+            received <- consumer.receiveJmsMessage
+            _        <- f(received, context, mf)
+          } yield ()
+      })
+      .repeat
+      .parJoin(concurrencyLevel)
+      .compile
+      .drain
+
+  private def take: Resource[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])] =
+    Resource.make(pool.take)(pool.offer)
+}
+
+object MessageConsumer {
+
+  private[jms4s] def pooled[F[_]: Async, A](
+    context: JmsContext[F],
+    inputDestinationName: DestinationName,
+    concurrencyLevel: Int,
+    pollingInterval: FiniteDuration,
+    sessionType: SessionType
+  ): Resource[F, MessageConsumer[F, Unit]] =
+    for {
+      pool <- Resource.eval(
+               Queue.bounded[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])](concurrencyLevel)
+             )
+      _ <- (0 until concurrencyLevel).toList.traverse_ { _ =>
+            for {
+              ctx      <- context.createContext(sessionType)
+              consumer <- ctx.createJmsConsumer(inputDestinationName, pollingInterval)
+              _        <- Resource.eval(pool.offer((ctx, consumer, MessageFactory[F](ctx))))
+            } yield ()
+          }
+    } yield new MessageConsumer(pool, concurrencyLevel)
+
+}

--- a/core/src/main/scala/jms4s/jms/MessageConsumer.scala
+++ b/core/src/main/scala/jms4s/jms/MessageConsumer.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2020 Functional Programming in Bologna
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package jms4s.jms
 
 import cats.effect.Resource
@@ -10,38 +31,34 @@ import jms4s.model.SessionType
 
 import scala.concurrent.duration.FiniteDuration
 
-private[jms4s] class MessageConsumer[F[_]: Concurrent, A](
+private[jms4s] class MessageConsumer[F[_]: Concurrent](
   pool: Queue[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])],
   concurrencyLevel: Int
 ) {
 
-  def consume(f: (JmsMessage, JmsContext[F], MessageFactory[F]) => F[A]): F[Unit] =
+  def consume[A](f: (JmsMessage, JmsContext[F], MessageFactory[F]) => F[A]): Stream[F, A] =
     Stream
-      .emit(Stream.resource(take).evalMap {
+      .emit(Stream.resource(poolResources).evalMap {
         case (context, consumer, mf) =>
-          for {
-            received <- consumer.receiveJmsMessage
-            _        <- f(received, context, mf)
-          } yield ()
+          consumer.receiveJmsMessage
+            .flatMap(received => f(received, context, mf))
       })
       .repeat
       .parJoin(concurrencyLevel)
-      .compile
-      .drain
 
-  private def take: Resource[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])] =
+  private def poolResources: Resource[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])] =
     Resource.make(pool.take)(pool.offer)
 }
 
 object MessageConsumer {
 
-  private[jms4s] def pooled[F[_]: Async, A](
+  private[jms4s] def pooled[F[_]: Async](
     context: JmsContext[F],
     inputDestinationName: DestinationName,
     concurrencyLevel: Int,
     pollingInterval: FiniteDuration,
     sessionType: SessionType
-  ): Resource[F, MessageConsumer[F, Unit]] =
+  ): Resource[F, MessageConsumer[F]] =
     for {
       pool <- Resource.eval(
                Queue.bounded[F, (JmsContext[F], JmsMessageConsumer[F], MessageFactory[F])](concurrencyLevel)

--- a/tests/src/test/scala/jms4s/JmsClientSpec.scala
+++ b/tests/src/test/scala/jms4s/JmsClientSpec.scala
@@ -23,7 +23,7 @@ package jms4s
 
 import cats.effect.testing.scalatest.AsyncIOSpec
 import cats.effect.{ Clock, IO, Ref, Resource }
-import cats.implicits._
+import cats.syntax.all._
 import jms4s.JmsAcknowledgerConsumer.AckAction
 import jms4s.JmsAutoAcknowledgerConsumer.AutoAckAction
 import jms4s.JmsTransactedConsumer.TransactionAction
@@ -411,7 +411,7 @@ trait JmsClientSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
     }
   }
 
-  s"sendN $nMessages messages with delay in a Queue with pooled producer and consume them" in {
+  s"send a message with delay in a Queue with producer and consume it" in {
     val res = for {
       jmsClient <- jmsClientRes
       context   = jmsClient.context

--- a/tests/src/test/scala/jms4s/jms/JmsSpec.scala
+++ b/tests/src/test/scala/jms4s/jms/JmsSpec.scala
@@ -38,7 +38,7 @@ trait JmsSpec extends AsyncFreeSpec with AsyncIOSpec with Jms4sBaseSpec {
       context = client.context
       receiveConsumer <- context
                           .createContext(SessionType.AutoAcknowledge)
-                          .flatMap(_.createJmsConsumer(destination, pollingInterval))
+                          .flatMap(_.createJmsConsumer(destination, 50.millis))
       sendContext <- context.createContext(SessionType.AutoAcknowledge)
       msg         <- Resource.eval(context.createTextMessage(body))
     } yield (receiveConsumer, sendContext, msg)


### PR DESCRIPTION
This PR move the logic of pooling, acquiring and releasing of JmsContext in a shared class(PooledConsumer) instead of being repeated in all the consumers.

