### PR TITLE
Fix logging dependencies for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,10 @@ lazy val tests = project
   .in(file("tests"))
   .settings(commonSettings, releaseSettings)
   .enablePlugins(NoPublishPlugin)
-  .settings(libraryDependencies += "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jSlf4jImplV % Runtime)
+  .settings(libraryDependencies ++= Seq(
+    "org.apache.logging.log4j" % "log4j-slf4j2-impl" % log4jSlf4jImplV % Runtime,
+    "org.apache.logging.log4j" % "log4j-core" % log4jSlf4jImplV % Runtime
+  ))
   .settings(Test / parallelExecution := false)
   .dependsOn(ibmMQ, activeMQArtemis)
 


### PR DESCRIPTION
The wrong version of the slf4j API was in-use which meant that the log4j slf4j binding was no longer loaded and that tests showed no log messages.

This PR switches the binding from `log4j-slf4j-impl` to `log4j-slf4j2-impl` (which also requires `log4j-core` be explicitly available on the classpath).